### PR TITLE
[FIX]: Responsive directional space

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -13,7 +13,19 @@ const breaks = props => [ null, ...(idx([ 'theme', 'breakpoints' ], props) || br
 const dec = props => val => arr(props)
   .reduce((acc, prop) => (acc[prop] = val, acc), {})
 const media = bp => (d, i) => bp[i] ? ({[bp[i]]: d}) : d
-const joinObj = (acc, obj) => Object.assign(acc, obj)
+const joinObj = (acc, obj) =>
+  Object.assign(
+    acc,
+    Object.keys(obj).reduce(
+      (result, key) =>
+        Object.assign(result, {
+          [key]: typeof acc[key] === 'object' && typeof obj[key] === 'object'
+            ? [acc[key], obj[key]].reduce(joinObj, {})
+            : obj[key],
+        }),
+      {}
+    )
+  );
 
 module.exports = {
   is,

--- a/test.js
+++ b/test.js
@@ -156,6 +156,18 @@ test('space returns responsive margins', t => {
   })
 })
 
+test('space returns responsive directional margins', t => {
+  const a = space({mt: [0, 1], mb: [2, 3]})
+  t.deepEqual(a, {
+    marginBottom: '16px',
+    marginTop: '0px',
+    '@media screen and (min-width: 40em)': {
+      marginBottom: '32px',
+      marginTop: '8px',
+    },
+  })
+})
+
 test('space returns padding declarations', t => {
   const dec = space({p: 1})
   t.deepEqual(dec, {padding: '8px'})
@@ -189,6 +201,18 @@ test('space returns responsive paddings', t => {
     padding: '0px',
     '@media screen and (min-width: 40em)': {
       padding: '8px',
+    },
+  })
+})
+
+test('space returns responsive directional paddings', t => {
+  const a = space({pt: [0, 1], pb: [2, 3]})
+  t.deepEqual(a, {
+    paddingBottom: '16px',
+    paddingTop: '0px',
+    '@media screen and (min-width: 40em)': {
+      paddingBottom: '32px',
+      paddingTop: '8px',
     },
   })
 })


### PR DESCRIPTION
I was also affected by #7 so I decided to have a look at it.

The problem is that the [current `joinObj` method](https://github.com/jxnblk/styled-system/blob/e21b4212b14f557f9a10c1f95fab654ce63b2b73/src/util.js#L16) does a shallow merge, which screws up the "media" entries (because those are objects).

Thank you so much @angusfretwell for those tests, they've made the fix super easy. I'm including your commit in my PR, so I guess that if this PR gets merged you should also get credit for your contribution. I hope that's ok with you :wink: 