### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,9 @@
   },
   "bundlesize": [
     { "path": "dist/*.js" }
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jxnblk/styled-system.git"
+  }
 }


### PR DESCRIPTION
This will add the link on the npm page as well as make octolinker work when clicking on styled-system.