### PR TITLE
Support alternate units for media queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ const Component = styled(BaseComponent)([],
 styled-system uses a mobile-first responsive approach,
 where any value set works from that breakpoint and wider.
 The default set of breakpoints aims to cover a wide range of devices from mobile to desktop.
+Breakpoints default to `em` but can be overridden by passing strings with unit appended.
 Breakpoints can be customized using styled-components' [ThemeProvider](#configuration).
 
 ```js
@@ -224,6 +225,11 @@ Breakpoints can be customized using styled-components' [ThemeProvider](#configur
 // @media screen and (min-width: 40em)
 // @media screen and (min-width: 52em)
 // @media screen and (min-width: 64em)
+
+[ '300px', '600px', '1200px' ]
+// @media screen and (min-width: 300px)
+// @media screen and (min-width: 600px)
+// @media screen and (min-width: 1200px)
 ```
 
 ## Font Size Scale

--- a/src/util.js
+++ b/src/util.js
@@ -3,11 +3,12 @@ const { breakpoints } = require('./constants')
 const is = n => n !== undefined && n !== null
 const num = n => typeof n === 'number' && !isNaN(n)
 const px = n => num(n) ? n + 'px' : n
+const em = n => num(n) ? n + 'em' : n
 const neg = n => n < 0
 const arr = n => Array.isArray(n) ? n : [ n ]
 const idx = (p, obj) => p.reduce((a, b) => (a && a[b]) ? a[b] : null, obj)
 
-const mq = n => `@media screen and (min-width: ${n}em)`
+const mq = n => `@media screen and (min-width: ${em(n)})`
 
 const breaks = props => [
   null,
@@ -32,6 +33,7 @@ const merge = (a, b) => Object.assign({}, a, b, Object.keys(b).reduce((obj, key)
 module.exports = {
   is,
   px,
+  em,
   neg,
   num,
   arr,

--- a/test.js
+++ b/test.js
@@ -52,6 +52,13 @@ test('util.px adds px unit to numbers', t => {
   t.is(b, '2em')
 })
 
+test('util.em adds em unit to numbers', t => {
+  const a = util.em(1)
+  const b = util.em('2px')
+  t.is(a, '1em')
+  t.is(b, '2px')
+})
+
 test('util.neg checks for negative number', t => {
   const a = util.neg(0)
   const b = util.neg(1)
@@ -103,6 +110,15 @@ test('util.breaks returns a media queries array', t => {
     },
   })
   t.deepEqual(a, [null, '@media screen and (min-width: 24em)'])
+})
+
+test('util.breaks accepts non-em breakpoints', t => {
+  const a = util.breaks({
+    theme: {
+      breakpoints: ["600px"],
+    },
+  })
+  t.deepEqual(a, [null, '@media screen and (min-width: 600px)'])
 })
 
 test('util.media returns media query wrapped rules', t => {


### PR DESCRIPTION
Currently `styled-system` only supports `em`s for media queries. This PR will allow users to use any unit when specifying theme breakpoints. 

- Add `em` function to append `em` to number
- Update README to show usage
- Test `em` function
- Test `px` media query w/ `util.break`

Looking to bring styled-system into our design system ~~and this is the only blocker~~. 

---
Edited: Not super important because we can also convert breakpoint units to ems for `styled-system`.
