### PR TITLE
Allow strings in spacing scale

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -38,9 +38,18 @@ module.exports = props => {
   }).reduce(merge, {})
 }
 
-const mx = scale => n => num(n)
-  ? px((scale[Math.abs(n)] || Math.abs(n)) * (neg(n) ? -1 : 1))
-  : n
+const mx = scale => n => {
+  if (!num(n)) {
+    return n
+  }
+
+  const value = scale[Math.abs(n)] || Math.abs(n)
+  if (!num(value)) {
+    return value
+  }
+
+  return px(value * (neg(n) ? -1 : 1));
+}
 
 const getProperties = key => {
   const [ a, b ] = key.split('')
@@ -62,4 +71,3 @@ const directions = {
   x: [ 'Left', 'Right' ],
   y: [ 'Top', 'Bottom' ],
 }
-

--- a/test.js
+++ b/test.js
@@ -306,6 +306,11 @@ test('space can be configured with a theme', t => {
   t.deepEqual(d, {margin: '24px'})
 })
 
+test('space can accept string values', t => {
+  const a = space({ theme: { space: ['1em', '2em'] }, m: -1 })
+  t.deepEqual(a, {margin: '2em'})
+})
+
 // width
 test('width returns percentage widths', t => {
   const a = width({width: 1 / 2})


### PR DESCRIPTION
This will allow people who are using non px units to pass in string values in the spacing scale. Like:
```javascript
const a = space({
  theme: { space: ['1em', '2em'] },
  m: 1
});
console.log(a); // { margin: '2em' }
```

Something I'm unsure about with this change is the case where a user has string values in the spacing scale and passes in a negative value for a prop that uses the spacing scale. So for example:
 ```javascript
const a = space({
  theme: { space: ['1em', '2em'] },
  m: -1 // <-- Normally would translate to themes.space[1] * -1
});
console.log(a); // { margin: '2em' }
```
Now that the value is a string we can't safely make it negative without doing some parsing

Closes #30 