### PR TITLE
Preset style function props

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,35 @@ const Component = styled(BaseComponent)([],
 )
 ```
 
+## Preset Style Functions
+
+`preset` allows you to set fallback props for your style functions.
+Most CSS-in-JS libraries don't strip out duplicate properties, this
+requires that you ensure proper ordering of styles.  
+
+
+```jsx
+import React from 'react'
+import styled from "styled-components"
+import { fontSize, space, color, preset } from "styled-system"
+
+// Example of named preset.
+const presetFontSize = preset(fontSize, { f: [24, 36, 60, 72] })
+
+const Button = styled.button`
+  ${presetFontSize} 
+  ${preset(color, { color: "red" })} 
+  ${space}
+`;
+
+const App = props => (
+  <div>
+    <Button f={[36, 40, 44, 50]}>Classic red button</Button>
+    <Button color="blue">New blue button</Button>
+  </div>
+)
+```
+
 ---
 
 ## Low-level style functions

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ const theme = require('./theme')
 const removeProps = require('./remove-props')
 const util = require('./util')
 const constants = require('./constants')
+const preset = require('./preset')
 
 module.exports = {
   space,
@@ -61,5 +62,6 @@ module.exports = {
   theme,
   removeProps,
   util,
-  constants
+  constants,
+  preset
 }

--- a/src/preset.js
+++ b/src/preset.js
@@ -1,0 +1,2 @@
+const { merge } = require('./util')
+module.exports = (fn, fallback = {}) => props => fn(merge(fallback, props))

--- a/test.js
+++ b/test.js
@@ -26,6 +26,7 @@ import system, {
   focus,
   active,
   disabled,
+  preset
 } from './src'
 
 const palette = palx('#07c')
@@ -968,4 +969,21 @@ test('disabled uses theme values', t => {
       backgroundColor: theme.colors.green,
     }
   })
+})
+
+test('preset uses fallback values when key is missing', t => {
+  const a = preset(color, { color: 'tomato' })({ bg: "green" })  
+  t.deepEqual(a, { color: 'tomato', backgroundColor: "green" })  
+})
+
+test('preset fallbacks can be overridden by component props', t => {
+  const a = preset(color, { color: 'tomato' })({ bg: "blue", color: "green" })  
+  t.deepEqual(a, { backgroundColor: "blue", color: 'green' })    
+})
+
+test('preset returns a new style function', t => {
+  const a = preset(color, { color: 'tomato' })
+  const b = a({ bg: "blue", color: "green" })  
+  t.deepEqual(typeof a, "function")
+  t.deepEqual(b, { backgroundColor: "blue", color: 'green' })  
 })


### PR DESCRIPTION
- Create `preset` function
- Export from library
- Add documentation/test

I ran into this issue when trying to override a button's base background color. I initially reordered my style functions to the end of the template literal, but this resulted in two properties with the same name being set in the style tag with the later property in the cascade winning.

![image](https://user-images.githubusercontent.com/3998604/31001233-463a5a3c-a4b0-11e7-80b2-6eb2c43677e8.png)

This PR adds a short-hand function `preset` that takes a style function and a fallback object as arguments and returns a new style function with defaults set.

[CodeSandbox example w/ longhand & shorthand version](https://codesandbox.io/s/0xl49my5nv)

```jsx
// Double styles
styled.a`
  ${color}
  color: red;
`

// Current long-hand
styled.a`${props => color(Object.assign({}, { color: "green" }, props)}`
styled.a`${props => color({ color: "green", ...props })}`

// Short-hand version
styled.a`preset(color, { color: "green" })`
```
