### PR TITLE
Fix border color

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -7,8 +7,7 @@ module.exports = ({
 }) => props => {
   const n = props[prop]
   if (!is(n)) return null
-  const scale = get(props, [ 'theme', key ].join('.'), {})
-  const val = scale[n] || n
+  const val = get(props, [ 'theme', key, n ].join('.'), n)
 
   return { [cssProperty || prop]: val }
 }

--- a/test.js
+++ b/test.js
@@ -36,7 +36,8 @@ const theme = {
   fontSizes: [12, 16, 18, 24, 36, 72],
   colors: {
     blue: '#07c',
-    green: '#1c0'
+    green: '#1c0',
+    gray: ['#ccc', '#555']
   }
 }
 
@@ -774,6 +775,11 @@ test('borderColor returns borderColor', t => {
 test('borderColor returns borderColor', t => {
   const a = borderColor({ borderColor: 'blue' })
   t.deepEqual(a, { borderColor: 'blue' })
+})
+
+test('borderColor returns borderColor', t => {
+  const a = borderColor({ theme, borderColor: 'gray.0' })
+  t.deepEqual(a, { borderColor: theme.colors.gray[0] })
 })
 
 test('borderWidth returns borderWidth and borderStyle', t => {


### PR DESCRIPTION
border color currently uses the style helper which does not use the `get` for retrieving nested values. Hence values like `borderColor="gray.4"` are ignored.

I have considered just extending the color helper but that would mean that `borderColor` would be responsive but since none of the other border helpers are responsive I kept it that way.

Feel free to discard or whatever …

🙏