### PR TITLE
Fix cleanElement refs

### DIFF
--- a/src/clean-element.js
+++ b/src/clean-element.js
@@ -1,18 +1,18 @@
 const React = require('react')
 
 const cleanElement = Component => {
-  const Cleaned = props => {
-    const next = {}
-    const keys = Object.keys(Cleaned.propTypes || {})
-    for (let key in props) {
-      if (keys.includes(key)) continue
-      next[key] = props[key]
+  return class Cleaned extends React.Component {
+    render() {
+      const next = {}
+      const keys = Object.keys(Cleaned.propTypes || {})
+      for (let key in this.props) {
+        if (keys.includes(key)) continue
+        next[key] = this.props[key]
+      }
+
+      return React.createElement(Component, next)
     }
-
-    return React.createElement(Component, next)
   }
-
-  return Cleaned
 }
 
 module.exports = cleanElement


### PR DESCRIPTION
`cleanElement` shouldn't be a stateless function, so we can pass refs through the tree.