### PR TITLE
added babel-engine-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ava": "^0.19.1",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
+    "babel-engine-plugin": "^0.1.2",
     "babel-loader": "^7.0.0",
     "babel-preset-env": "^1.5.2",
     "babel-preset-react": "^6.24.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,13 @@
 const path = require('path')
+const BabelEnginePlugin = require('babel-engine-plugin');
 
 module.exports = {
   entry: './docs/entry.js',
-
+  plugins: [
+    new BabelEnginePlugin({
+      presets: ['env']
+    })
+  ],
   output: {
     filename: 'bundle.js',
     path: path.join(__dirname, 'docs')


### PR DESCRIPTION
Hey, I noticed that recently dot-prop updated and broke the build because of their lack of es6 support. I think this should solve the problem but don't have a good way of testing. Can you take a look?