### PR TITLE
WIP: remove empty css blocks

### DIFF
--- a/src/responsive-style.js
+++ b/src/responsive-style.js
@@ -22,11 +22,12 @@ module.exports = (...args) => props => {
   const sx = val => get(scale, '' + val, numberToPx ? px(val) : val)
 
   if (!Array.isArray(n)) {
-    return {
-      [cssProperty]: sx(
-        bool(boolValue)(n)
-      )
-    }
+    const val = sx(
+      bool(boolValue)(n)
+    )
+    return is(val) ? {
+      [cssProperty]: val
+    } : null
   }
 
   const val = arr(n)

--- a/src/space.js
+++ b/src/space.js
@@ -7,7 +7,8 @@ const {
   breaks,
   dec,
   media,
-  merge
+  merge,
+  is
 } = require('./util')
 const { space } = require('./constants')
 
@@ -25,9 +26,10 @@ module.exports = props => {
     const p = getProperties(key)
 
     if (!Array.isArray(val)) {
-      return p.reduce((a, b) => Object.assign(a, {
-        [b]: mx(sc)(val)
-      }), {})
+      const value = mx(sc)(val)
+      return is(value) ? p.reduce((a, b) => Object.assign(a, {
+        [b]: value
+      }), {}) : {}
     }
 
     return arr(val)
@@ -39,6 +41,10 @@ module.exports = props => {
 }
 
 const mx = scale => n => {
+  if (!is(n)) {
+    return null
+  }
+
   if (!num(n)) {
     return n
   }

--- a/src/util.js
+++ b/src/util.js
@@ -18,11 +18,15 @@ const breaks = props => [
 ]
 
 const dec = props => val => arr(props)
-  .reduce((acc, prop) => (acc[prop] = val, acc), {})
+  .reduce((acc, prop) => {
+    if (is(val)) acc[prop] = val
+    return acc
+  }, {})
 
-const media = bp => (d, i) => is(d)
+const media = bp => (d, i) =>
+  is(d) && !(typeof d === 'object' && Object.keys(d).length === 0)
   ? bp[i] ? ({ [bp[i]]: d }) : d
-  : null
+  : {}
 
 const merge = (a, b) => Object.assign({}, a, b, Object.keys(b).reduce((obj, key) =>
   Object.assign(obj, {

--- a/src/width.js
+++ b/src/width.js
@@ -5,9 +5,10 @@ module.exports = props => {
   if (!is(n)) return null
 
   if (!Array.isArray(n)) {
-    return {
+    const val = wx(n)
+    return is(val) ? {
       width: wx(n)
-    }
+    } : null
   }
 
   const bp = breaks(props)

--- a/test.js
+++ b/test.js
@@ -155,14 +155,18 @@ test('util.media returns media query wrapped rules', t => {
   const c = util.media([ 'hi' ])(null, 0)
   t.is(a, 'hello')
   t.deepEqual(b, { hi: 'hello' })
-  t.is(c, null)
+  t.deepEqual(c, {})
 })
 
 test('util.dec returns declaration strings', t => {
   const a = util.dec('foo')('bar')
   const b = util.dec(['foo', 'baz'])('bar')
+  const c = util.dec('foo')(null)
+  const d = util.dec(['foo', 'baz'])(null)
   t.deepEqual(a, {foo: 'bar'})
   t.deepEqual(b, {foo: 'bar', baz: 'bar'})
+  t.deepEqual(c, {})
+  t.deepEqual(d, {})
 })
 
 test('util.merge reduces objects', t => {
@@ -355,6 +359,11 @@ test('space can accept string values', t => {
   t.deepEqual(a, {margin: '2em'})
 })
 
+test('space returns an empty object', t => {
+  const dec = space({m: null})
+  t.deepEqual(dec, {})
+})
+
 // width
 test('width returns percentage widths', t => {
   const a = width({width: 1 / 2})
@@ -394,7 +403,9 @@ test('width returns 0 value', t => {
 
 test('width returns null ', t => {
   const a = width({})
+  const b = width({width: null})
   t.is(a, null)
+  t.is(b, null)
 })
 
 test('width accepts shortcut prop', t => {
@@ -596,10 +607,18 @@ test('responsiveStyle allows property aliases', t => {
 test('responsiveStyle allows array values', t => {
   const direction = responsiveStyle('flex-direction', 'direction')
   const a = direction({ direction: [ 'column', null, 'row' ] })
+  const b = direction({ direction: [ 'column', false, 'row' ] })
+  const result = 
   t.deepEqual(a, {
     'flex-direction': 'column',
+    '@media screen and (min-width: 52em)': {
+      'flex-direction': 'row',
+    }
+  })
+  t.deepEqual(b, {
+    'flex-direction': 'column',
     '@media screen and (min-width: 40em)': {
-      'flex-direction': null
+      'flex-direction': false
     },
     '@media screen and (min-width: 52em)': {
       'flex-direction': 'row',
@@ -610,8 +629,12 @@ test('responsiveStyle allows array values', t => {
 test('responsiveStyle can be configured for boolean props', t => {
   const wrap = responsiveStyle('flex-wrap', 'wrap', 'wrap')
   const a = wrap({ wrap: true })
+  const b = wrap({ wrap: false })
   t.deepEqual(a, {
     'flex-wrap': 'wrap'
+  })
+  t.deepEqual(b, {
+    'flex-wrap': false
   })
 })
 
@@ -717,6 +740,20 @@ test('responsiveStyle returns a theme number value in px', t => {
       borderRadius: theme.radii[1],
     }
   })
+})
+
+test('responsiveStyle returns null', t => {
+  const order = responsiveStyle('order')
+  const a = order({})
+  const b = order({order: null})
+  t.is(a, null)
+  t.is(b, null)
+})
+
+test('responsiveStyle returns an empty object', t => {
+  const order = responsiveStyle('order')
+  const a = order({ order: [ null, null, undefined] })
+  t.deepEqual(a, {})
 })
 
 test('psuedoStyle returns a function', t => {


### PR DESCRIPTION
Cleanup the generated css by removing all the empty blocks.

As you can see bellow, null doesn't generate useless blocks like false do. I created a lib on top of `styled-system` and the difference on a big app is huge.

```js
test('responsiveStyle allows array values', t => {
  const direction = responsiveStyle('flex-direction', 'direction')
  const a = direction({ direction: [ 'column', null, 'row' ] })
  const b = direction({ direction: [ 'column', false, 'row' ] })
  const result = 
  t.deepEqual(a, {
    'flex-direction': 'column',
    '@media screen and (min-width: 52em)': {
      'flex-direction': 'row',
    }
  })
  t.deepEqual(b, {
    'flex-direction': 'column',
    '@media screen and (min-width: 40em)': {
      'flex-direction': false
    },
    '@media screen and (min-width: 52em)': {
      'flex-direction': 'row',
    }
  })
})
```

I may have forgotten some parsers like border.