### PR TITLE
Add ability to specify false value for responsiveStyle bool prop

### DIFF
--- a/src/responsive-style.js
+++ b/src/responsive-style.js
@@ -38,4 +38,9 @@ module.exports = (...args) => props => {
     .reduce(merge, {})
 }
 
-const bool = val => n => n === true ? val : n
+const bool = val => n => {
+  if (Array.isArray(val))
+    return n === true ? val[0] : val[1];
+
+  return n === true ? val : n;
+}

--- a/test.js
+++ b/test.js
@@ -617,6 +617,14 @@ test('responsiveStyle can be configured for boolean props', t => {
   })
 })
 
+test('responsiveStyle can be configured with boolean fallback array', t => {
+  const wrap = responsiveStyle('flex-wrap', 'wrap', ['wrap', 'nowrap'])
+  const a = wrap({ wrap: false })
+  t.deepEqual(a, {
+    'flex-wrap': 'nowrap'
+  })
+})
+
 test('responsiveStyle boolean props handle arrays', t => {
   const wrap = responsiveStyle('flex-wrap', 'wrap', 'wrap')
   const a = wrap({ wrap: [ true, false ] })
@@ -624,6 +632,17 @@ test('responsiveStyle boolean props handle arrays', t => {
     'flex-wrap': 'wrap',
     '@media screen and (min-width: 40em)': {
       'flex-wrap': false
+    }
+  })
+})
+
+test('responsiveStyle boolean fallback props handle arrays', t => {
+  const wrap = responsiveStyle('flex-wrap', 'wrap', ['wrap', 'nowrap'])
+  const a = wrap({ wrap: [true, false] })
+  t.deepEqual(a, {
+    'flex-wrap': 'wrap',
+    '@media screen and (min-width: 40em)': {
+      'flex-wrap': 'nowrap'
     }
   })
 })


### PR DESCRIPTION
Currently boolean values for responsive styles don't work exactly as expected. When `true` the output is correct, but if `false` the output css value is `false` which doesn't always work.

```jsx
<Flex wrap={[ true, false ]}>
...
</Flex>
```
The above will always function as `flex-wrap: wrap` since the output is like this:
```css
flex-wrap: wrap;
@media (min-width: 40em) {
  flex-wrap: false;
}
```

when in reality we're want:
```css
flex-wrap: wrap;
@media (min-width: 40em) {
  flex-wrap: nowrap;
}
```

This PR lets `responsiveStyle`'s third argument take an array of two values: `[ 'if true', 'if false' ]` 

For example:
```js
const wrap = responsiveStyle('flex-wrap', 'wrap', ['wrap', 'nowrap'])
```
would output the desired css.

---
related #32