### PR TITLE
Add example fallback radius for theme function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ import styled from 'styled-components'
 import { theme } from 'styled-system'
 
 const Box = styled.div`
-  border-radius: ${theme('radii.small')};
+  border-radius: ${theme('radii.small', '4px')};
 `
 ```
 


### PR DESCRIPTION
I assumed the fallback was just a second arg to the `theme` function, but I had to check the source to be sure.  This PR just includes the fallback in the example in the README.