### PR TITLE
clean-tag: Fix bug preventing props from getting passed by exported HTML tags

### DIFF
--- a/clean-tag/index.js
+++ b/clean-tag/index.js
@@ -44,7 +44,7 @@ Tag.defaultProps = {
 Tag.styledComponentId = 'lol'
 
 tags.forEach(tag => {
-  Tag[tag] = props => React.createElement(Tag, { is: tag })
+  Tag[tag] = props => React.createElement(Tag, { is: tag, ...props })
   Tag[tag].displayName = 'Clean.' + tag
 })
 

--- a/clean-tag/test.js
+++ b/clean-tag/test.js
@@ -28,3 +28,16 @@ test('exports html tags', t => {
   t.is(h1.type, 'h1')
   t.is(header.type, 'header')
 })
+
+test('exported html tags only omit blacklisted props', t => {
+  const json = render(React.createElement(tag.h1, {
+    id: 'hello',
+    m: 2,
+    px: 3,
+    color: 'blue'
+  })).toJSON()
+  t.is(json.props.m, undefined)
+  t.is(json.props.px, undefined)
+  t.is(json.props.blue, undefined)
+  t.is(json.props.id, 'hello')
+})


### PR DESCRIPTION
This fixes a bug in `clean-tag` causing props passed to exported HTML tags (e.g. `tag.h1`) to not get passed on to children.

Here's a little demo showing the issue & solution: https://codesandbox.io/s/xp60z1v33o