### PR TITLE
Add examples to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,6 +10,7 @@ src
 
 clean-element
 clean-tag
+examples
 system-components
 system-classnames
 system-loader


### PR DESCRIPTION
Examples folder is 172MB so it takes up a lot of space as an npm package which becomes an issue in certain environments. 