### PR TITLE
document that borderRadius is responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ Function Name | Prop       | CSS Property    | Theme Field  | Responsive
 
 Function Name | Prop       | CSS Property    | Theme Field  | Responsive
 --------------|------------|-----------------|--------------|-----------
-`borderRadius` | `borderRadius` | `border-radius` | `radii` | no
+`borderRadius` | `borderRadius` | `border-radius` | `radii` | yes
 `borderColor` | `borderColor` | `border-color` | `colors` | no
 `borders` | `border` | `border` | `borders` | yes
 `borders` | `borderTop` | `border-top` | `borders` | yes


### PR DESCRIPTION
Document that `borderRadius` is responsive.

https://github.com/jxnblk/styled-system/issues/58#issuecomment-362851423.

This will likely cause a merge conflict with #115.

I think that #58 should be reopened until either #115 is merged with this change or this PR is merged.  I spent a while trying to get `borderRadius` to work and was only successful when I found the above comment.