### PR TITLE
modify mx space to allow negative strings on the scale

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -1,83 +1,79 @@
-import PropTypes from 'prop-types'
-import {
-  get,
-  arr,
-  px,
-  neg,
-  num,
-  breaks,
-  dec,
-  media,
-  merge
-} from './util'
-import theme from './constants'
+import PropTypes from "prop-types";
+import { get, arr, px, neg, num, breaks, dec, media, merge } from "./util";
+import theme from "./constants";
 
-const REG = /^[mp][trblxy]?$/
+const REG = /^[mp][trblxy]?$/;
 
 export const space = props => {
   const keys = Object.keys(props)
     .filter(key => REG.test(key))
-    .sort()
-  const bp = breaks(props)
-  const sc = get(props, 'theme.space', theme.space)
+    .sort();
+  const bp = breaks(props);
+  const sc = get(props, "theme.space", theme.space);
+  // console.log(sc);
+  return keys
+    .map(key => {
+      const val = props[key];
+      const p = getProperties(key);
 
-  return keys.map(key => {
-    const val = props[key]
-    const p = getProperties(key)
+      if (!Array.isArray(val)) {
+        return p.reduce(
+          (a, b) =>
+            Object.assign(a, {
+              [b]: mx(sc)(val)
+            }),
+          {}
+        );
+      }
 
-    if (!Array.isArray(val)) {
-      return p.reduce((a, b) => Object.assign(a, {
-        [b]: mx(sc)(val)
-      }), {})
-    }
-
-    return arr(val)
-      .map(mx(sc))
-      .map(dec(p))
-      .map(media(bp))
-      .reduce(merge, {})
-  }).reduce(merge, {})
-}
+      return arr(val)
+        .map(mx(sc))
+        .map(dec(p))
+        .map(media(bp))
+        .reduce(merge, {});
+    })
+    .reduce(merge, {});
+};
 
 const mx = scale => n => {
   if (!num(n)) {
-    return n
+    return n;
   }
 
-  const value = scale[Math.abs(n)] || Math.abs(n)
+  const value = scale[Math.abs(n)] || Math.abs(n);
   if (!num(value)) {
-    return value
+    return neg(n) ? `-${value}` : value;
   }
 
   return px(value * (neg(n) ? -1 : 1));
-}
+};
 
 const getProperties = key => {
-  const [ a, b ] = key.split('')
-  const prop = properties[a]
-  const dirs = directions[b] || [ '' ]
-  return dirs.map(dir => prop + dir)
-}
+  const [a, b] = key.split("");
+  const prop = properties[a];
+  const dirs = directions[b] || [""];
+  return dirs.map(dir => prop + dir);
+};
 
 const properties = {
-  m: 'margin',
-  p: 'padding'
-}
+  m: "margin",
+  p: "padding"
+};
 
 const directions = {
-  t: [ 'Top' ],
-  r: [ 'Right' ],
-  b: [ 'Bottom' ],
-  l: [ 'Left' ],
-  x: [ 'Left', 'Right' ],
-  y: [ 'Top', 'Bottom' ],
-}
+  t: ["Top"],
+  r: ["Right"],
+  b: ["Bottom"],
+  l: ["Left"],
+  x: ["Left", "Right"],
+  y: ["Top", "Bottom"]
+};
 
 const responsive = PropTypes.oneOfType([
   PropTypes.number,
   PropTypes.string,
   PropTypes.array
-])
+]);
 
 space.propTypes = {
   m: responsive,
@@ -94,6 +90,6 @@ space.propTypes = {
   pl: responsive,
   px: responsive,
   py: responsive
-}
+};
 
-export default space
+export default space;

--- a/test.js
+++ b/test.js
@@ -376,8 +376,13 @@ test('space can be configured with a theme', t => {
 })
 
 test('space can accept string values', t => {
-  const a = space({ theme: { space: ['1em', '2em'] }, m: -1 })
+  const a = space({ theme: { space: ['1em', '2em'] }, m: 1 })
   t.deepEqual(a, {margin: '2em'})
+})
+
+test('space can accept string values with negative', t => {
+  const a = space({ theme: { space: ['1em', '2em'] }, m: -1 })
+  t.deepEqual(a, {margin: '-2em'})
 })
 
 // width


### PR DESCRIPTION
This pull request allows using the negative values of a string based scale.

E.g

`
const space = ['1rem', '2rem', '3rem'];

//before
<Component mx={-1} /> // margin-left: 2rem, margin-right: 2rem;
// after
<Component mx={-1} /> // margin-left: -2rem, margin-right: -2rem;
`