### PR TITLE
Move getWidth to utils

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -3,13 +3,13 @@ import {
   style,
   pseudoStyle,
   responsiveStyle,
-  complexStyle
+  complexStyle,
+  getWidth
 } from './util'
 
 // core
 export { default as space } from './space'
 
-const getWidth = n => !util.num(n) || n > 1 ? util.px(n) : (n * 100) + '%'
 export const width = responsiveStyle({
   prop: 'width',
   alias: 'w',

--- a/src/util.js
+++ b/src/util.js
@@ -19,6 +19,7 @@ export const px = n => num(n) ? n + 'px' : n
 export const neg = n => n < 0
 export const arr = n => Array.isArray(n) ? n : [ n ]
 
+export const getWidth = n => !num(n) || n > 1 ? px(n) : (n * 100) + '%'
 export const get = (obj, path, fallback) => path.split('.')
   .reduce((a, b) => (a && a[b]) ? a[b] : null, obj) || fallback
 


### PR DESCRIPTION
Moving getWidth to utils will allow it to be
used by end users via the util export. This is
useful when you want to use getWidth for a different
style function. For example, defining the same
height as the width prop for an icon or avatar.