### PR TITLE
Make sure we're getting the value from an object and not string when getting styles from style object 

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -21,7 +21,7 @@ export const arr = n => Array.isArray(n) ? n : [ n ]
 
 export const getWidth = n => !num(n) || n > 1 ? px(n) : (n * 100) + '%'
 export const get = (obj, path, fallback) => path.split('.')
-  .reduce((a, b) => (a && a[b]) ? a[b] : null, obj) || fallback
+  .reduce((a, b) => (typeof a === 'object' && a && a[b]) ? a[b] : null, obj) || fallback
 
 export const mq = n => `@media screen and (min-width: ${px(n)})`
 


### PR DESCRIPTION
I have been having this issue where setting `width={1}` on a component gives the the width `0%`. 

I have managed to track down the issue and it seems that when getting the styles from the styles object it tries to get the key `1` from the string `"100%"` which happens to be `"0"`. Since `"0"` is a truthy value that is returned as the style setting. (See image below)

![image](https://user-images.githubusercontent.com/5450545/40233407-25e0db04-5aa3-11e8-92a4-9fc060fb318c.png)

My proposed fix for this is to when reducing the style from the styles object check if a is an object and only then get they value of a[b] . If a is not an object and there is still path parameters left then there is no possible match for the full path so we should return `null` to use the fallback value instead.
