### PR TITLE
Fix innerRef for system-components

### DIFF
--- a/system-components/src/System.js
+++ b/system-components/src/System.js
@@ -57,6 +57,7 @@ class System {
 
       const div = props => React.createElement(tag, props)
       div.defaultProps = { blacklist }
+      div.styledComponentId = 'lol' // Trick styled-components into passing innerRef
 
       const Component = createComponent(div)(...funcs)
 


### PR DESCRIPTION
Solves jxnblk/rebass#329

StyledComponents doesn't properly recognize the generated wrapper and assigns it `ref`, when we actually want to pass through `innerRef`