### PR TITLE
Added `createSystem` export that allows to use `styled` from other libraries

### DIFF
--- a/system-components/README.md
+++ b/system-components/README.md
@@ -113,6 +113,19 @@ const Bold = Text.extend`
 `
 ```
 
+## Usage with other css-in-js libraries
+
+By default, `system-components` use `styled-components` to when using default `system` export.
+
+You can create your own `system` interface that will only use your css-in-js library.
+
+```js
+import { createSystem } from 'system-components'
+import styled from 'react-emotion'
+
+// creates a system function, that use `styled` from your library
+const system = createSystem(styled)
+```
 
 ---
 

--- a/system-components/src/index.js
+++ b/system-components/src/index.js
@@ -1,8 +1,10 @@
 import styled from 'styled-components'
 import System from './System'
 
-const create = new System({
-  createComponent: type => (...args) => styled(type)([], ...args)
+export const createSystem = (styledFn) => new System({
+  createComponent: type => (...args) => styledFn(type)([], ...args)
 })
+
+const create = createSystem(styled)
 
 export default create

--- a/system-components/test.js
+++ b/system-components/test.js
@@ -7,7 +7,7 @@ import { propTypes } from 'styled-system'
 import React from 'react'
 import { create as render } from 'react-test-renderer'
 import { isDOMComponent, isCompositeComponent } from 'react-dom/test-utils'
-import system from './src'
+import system, { createSystem } from './src'
 
 // 😎
 const { StyleSheet } = __DO_NOT_USE_OR_YOU_WILL_BE_HAUNTED_BY_SPOOKY_GHOSTS
@@ -155,4 +155,15 @@ test('defaultProps are passed to extended components', t => {
   const json = render(<ExtendedBox />).toJSON()
   const css = getCSS()
   t.regex(css, /background-color:tomato/)
+})
+
+test('creates system interface form `styled` function', t => {
+  const mySystem = createSystem(styled)
+  const Box = mySystem({
+    p: 2,
+    bg: 'hotpink'
+  }, 'space', 'color')
+  const json = render(<Box />).toJSON()
+  const css = getCSS()
+  t.regex(css, /background-color:hotpink/)
 })


### PR DESCRIPTION
Hello, I love `styled-system`, I'm a fan 👍 

But I also love `emotion` and was devastated to learn that in fact - I'm using `styled-components`  when using `system-components` 😭 

More serious: If your project already use other css-in-js library, you unnecessarily add `styled-components` to your bundle size (it gets even worse if you don't tree shake). Also, typescript definitions are work-in-progress but I'm sure I would quickly notice that my component type is incompatible with the `StyledComponent` type from i.e `emotion`.

So what I did:
- [x] It was just two lines of code to add createSystem export, that allows to create system interface that use any css-in-js library `styled` function.
```js
import { createSystem } from 'system-components'
import styled from 'react-emotion'

// creates a system function, that use `styled` from your library
const system = createSystem(styled)
```
- [x] Added test (it works, there's nothing to break- but I also tested it on some CRA with styled-components and emotion)
- [x] Added small section in readme (maybe could use a bit of polishing)

Hope you'll accept!
