### PR TITLE
Responsive size styles not being correctly merged in

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -120,7 +120,7 @@ export const sizeHeight = responsiveStyle({
 })
 
 export const size = props => 
-  merge(sizeHeight2(props), sizeWidth2(props))
+  merge(sizeHeight(props), sizeWidth(props))
 
 size.propTypes = {
   ...sizeWidth.propTypes,

--- a/src/styles.js
+++ b/src/styles.js
@@ -4,7 +4,8 @@ import {
   pseudoStyle,
   responsiveStyle,
   complexStyle,
-  getWidth
+  getWidth,
+  merge
 } from './util'
 
 // core

--- a/src/styles.js
+++ b/src/styles.js
@@ -119,10 +119,9 @@ export const sizeHeight = responsiveStyle({
   numberToPx: true
 })
 
-export const size = props => ({
-  ...sizeWidth(props),
-  ...sizeHeight(props)
-})
+export const size = props => 
+  merge(sizeHeight2(props), sizeWidth2(props))
+
 size.propTypes = {
   ...sizeWidth.propTypes,
   ...sizeHeight.propTypes,


### PR DESCRIPTION
The size style is not merging in media queries correctly because  it's not deep merging and so the media query property is just clobbered by the second (height) style. I noticed while using it with a responsive svg element.