### PR TITLE
Added opacity style prop

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,7 @@
   - [width](#width-responsive)
   - [fontSize](#fontsize-responsive)
   - [color](#color-responsive) (and background-color)
+  - [opacity](#opacity)
 - [Typography](#typography)
 - [Layout](#layout)
 - [Flexbox](#flexbox)
@@ -157,6 +158,24 @@ Array values are converted into [responsive values][responsive-styles].
 
 // raw CSS color value
 <Box color='#f00' />
+```
+
+### opacity (responsive)
+
+
+```js
+import { opacity } from 'styled-system'
+```
+
+The opacity utility parses a component's `opacity` prop and converts it into a CSS declaration.
+
+```jsx
+// examples
+
+<Box opacity={0.5} />
+
+// with responsive values
+<Box opacity={[0.3, 0.7]} />
 ```
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,6 @@
   - [width](#width-responsive)
   - [fontSize](#fontsize-responsive)
   - [color](#color-responsive) (and background-color)
-  - [opacity](#opacity)
 - [Typography](#typography)
 - [Layout](#layout)
 - [Flexbox](#flexbox)
@@ -160,24 +159,6 @@ Array values are converted into [responsive values][responsive-styles].
 <Box color='#f00' />
 ```
 
-### opacity (responsive)
-
-
-```js
-import { opacity } from 'styled-system'
-```
-
-The opacity utility parses a component's `opacity` prop and converts it into a CSS declaration.
-
-```jsx
-// examples
-
-<Box opacity={0.5} />
-
-// with responsive values
-<Box opacity={[0.3, 0.7]} />
-```
-
 ---
 
 ## Typography
@@ -316,6 +297,9 @@ The `borders` utility combines `border`, `borderTop`, `borderRight`, `borderBott
   backgroundPosition='center'
   backgroundRepeat='repeat-x'
 />
+
+// opacity
+<Box opacity={0.5} />
 ```
 
 ## Pseudo-classes

--- a/docs/table.md
+++ b/docs/table.md
@@ -19,6 +19,7 @@ Function Name | Prop       | CSS Property    | Theme Field  | Responsive
 `fontSize`    | `fontSize` |`font-size`      |`fontSizes`   | yes
 `color`       | `color`    | `color`         | `colors`     | yes
 `color`       | `bg`       | `background-color`| `colors`   | yes
+`opacity`     | `opacity` `o` | `opacity`    | `opacity`    | yes
 
 ## Typography
 

--- a/docs/table.md
+++ b/docs/table.md
@@ -19,7 +19,6 @@ Function Name | Prop       | CSS Property    | Theme Field  | Responsive
 `fontSize`    | `fontSize` |`font-size`      |`fontSizes`   | yes
 `color`       | `color`    | `color`         | `colors`     | yes
 `color`       | `bg`       | `background-color`| `colors`   | yes
-`opacity`     | `opacity` `o` | `opacity`    | `opacity`    | yes
 
 ## Typography
 
@@ -97,6 +96,7 @@ Function Name | Prop       | CSS Property    | Theme Field  | Responsive
 `borders` | `borderBottom` | `border-bottom` | `borders` | yes
 `borders` | `borderLeft` | `border-left` | `borders` | yes
 `boxShadow` | `boxShadow` | `box-shadow` | `shadows` | no
+`opacity`   | `opacity` `o` | `opacity`  | `opacity` | yes
 
 ## Position
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export {
   textColor,
   bgColor,
   color,
+  opacity,
   // typography
   fontFamily,
   textAlign,

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ export {
   textColor,
   bgColor,
   color,
-  opacity,
   // typography
   fontFamily,
   textAlign,
@@ -62,6 +61,7 @@ export {
   backgroundSize,
   backgroundPosition,
   backgroundRepeat,
+  opacity,
   // position
   position,
   zIndex,

--- a/src/styles.js
+++ b/src/styles.js
@@ -44,8 +44,7 @@ color.propTypes = {
 }
 
 export const opacity = responsiveStyle({
-  prop: 'opacity',
-  alias: 'o',
+  prop: 'opacity'
 })
 
 // typography

--- a/src/styles.js
+++ b/src/styles.js
@@ -43,6 +43,11 @@ color.propTypes = {
   ...bgColor.propTypes,
 }
 
+export const opacity = responsiveStyle({
+  prop: 'opacity',
+  alias: 'o',
+})
+
 // typography
 export const fontFamily = style({
   prop: 'fontFamily',

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ import {
   width,
   fontSize,
   color,
+  opacity,
 
   style,
   responsiveStyle,
@@ -536,6 +537,22 @@ test('color keys support dot notation', t => {
     color: 'gray.2'
   })
   t.is(a.color, '#999')
+})
+
+// opacity
+test('opacity', t => {
+  const a = opacity({ opacity: 0.5 })
+  t.deepEqual(a, { opacity: 0.5 })
+})
+
+test('opacity responsive', t => {
+  const a = opacity({ opacity: [0.3, 0.7] })
+  t.deepEqual(a, {
+    opacity: 0.3,
+    '@media screen and (min-width: 40em)': {
+      opacity: 0.7,
+    }
+  })
 })
 
 // style


### PR DESCRIPTION
Couldn't find anything in styled system for an `opacity` prop, so this adds it (as well as a few tests and updates to the documentation.) Also includes the shorthand `o`. This is a CSS value that is used a lot, so this could be really useful to have in the core.