### PR TITLE
Add default object to fix merge issue

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -121,7 +121,7 @@ export const sizeHeight = responsiveStyle({
 })
 
 export const size = props => 
-  merge(sizeHeight(props), sizeWidth(props))
+  merge(sizeHeight(props) || {}, sizeWidth(props) || {})
 
 size.propTypes = {
   ...sizeWidth.propTypes,


### PR DESCRIPTION
As reported here https://github.com/jxnblk/styled-system/issues/199, the deep merge fix seems to have caused problems due to a null object being sent to `merge`. I've added default empty objects to avoid this.