### PR TITLE
Allow Alias for spacing

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -41,7 +41,7 @@ export const space = props => {
 
 const mx = scale => n => {
   if (!num(n)) {
-    return n
+    return scale[n] || n
   }
 
   const value = scale[Math.abs(n)] || Math.abs(n)


### PR DESCRIPTION
I am currently working on a design system that defines spacing like the following:

```js
export const space = [0, 2, 4, 16, 24, 32, 48, 64];
```

I would really like to access them via aliases e.g. 
```js
            <Box pt="xs" bg="primary">
              xs
            </Box>
```

With this PR, you can define aliases on your space scale. For example with this helper function
```js

const addAliases = (arr, aliases) =>
  aliases.forEach((key, i) =>
    Object.defineProperty(arr, key, {
      enumerable: false,
      get() {
        return this[i];
      }
    })
  );

export const space = [0, 2, 4, 16, 24, 32, 48, 64];
addAliases(space, ["none", "xxs", "xs", "s", "m", "l", "xl", "xxl"]);
```