### PR TITLE
Remove babel configuration from the npm dist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 coverage
 coverage.lcov
 .travis.yml
+.babelrc
 test.js
 bench
 docs


### PR DESCRIPTION
The **styled-system** `.babelrc` is being picked up babel when running react-native projects - this should not be happening and it's easily fixed by removing `.babelrc` from npm.

This should allow react-native projects to work with this lib. See #203 and https://github.com/babel/babel/issues/6766 for more info.