### PR TITLE
clean-tag v2

### DIFF
--- a/clean-tag/index.js
+++ b/clean-tag/index.js
@@ -17,33 +17,20 @@ export const omit = (obj, keys) => {
   return next
 }
 
-export class Tag extends React.Component {
-  render () {
-    const {
-      innerRef,
-      is,
-      blacklist,
-      theme,
-      ...props
-    } = this.props
-    const attr = omit(props, blacklist)
-
-    return React.createElement(is, {
-      ref: innerRef,
-      ...attr
-    })
-  }
-}
+export const Tag = React.forwardRef(({
+  is: Tag = 'div',
+  blacklist = [],
+  ...props
+}, ref) => React.createElement(Tag, {
+  ref,
+  ...omit(props, blacklist)
+}))
 
 Tag.displayName = 'Clean.div'
 
 Tag.defaultProps = {
-  is: 'div',
   blacklist
 }
-
-// Trick styled-components into passing innerRef
-Tag.styledComponentId = 'lol'
 
 tags.forEach(tag => {
   Tag[tag] = props => React.createElement(Tag, { is: tag, ...props })

--- a/clean-tag/index.js
+++ b/clean-tag/index.js
@@ -6,7 +6,7 @@ const allPropTypes = Object.keys(styles)
   .filter(key => typeof styles[key] === 'function')
   .reduce((a, key) => Object.assign(a, styles[key].propTypes), {})
 
-const blacklist = Object.keys(allPropTypes)
+const blacklist = [ ...Object.keys(allPropTypes), 'theme' ]
 
 export const omit = (obj, keys) => {
   const next = {}

--- a/clean-tag/test.js
+++ b/clean-tag/test.js
@@ -41,3 +41,28 @@ test('exported html tags only omit blacklisted props', t => {
   t.is(json.props.blue, undefined)
   t.is(json.props.id, 'hello')
 })
+
+test('accepts an is prop to change the underlying element', t => {
+  const json = render(React.createElement(tag, {
+    is: 'header'
+  })).toJSON()
+  t.is(json.type, 'header')
+})
+
+test('accepts a custom blacklist', t => {
+  const json = render(React.createElement(tag, {
+    hello: 'hi',
+    blacklist: [ 'hello' ]
+  })).toJSON()
+  t.is(json.props.hello, undefined)
+})
+
+test('forwards ref', t => {
+  let ref = 'hi'
+  const json = render(
+    React.createElement(tag, {
+      ref: r => ref = r
+    })
+  ).toJSON()
+  t.not(ref, 'hi')
+})

--- a/clean-tag/test.js
+++ b/clean-tag/test.js
@@ -12,6 +12,7 @@ test('renders', t => {
 test('omits props', t => {
   const json = render(React.createElement(tag, {
     id: 'hello',
+    theme: {},
     m: 2,
     px: 3,
     color: 'blue'
@@ -19,6 +20,7 @@ test('omits props', t => {
   t.is(json.props.m, undefined)
   t.is(json.props.px, undefined)
   t.is(json.props.blue, undefined)
+  t.is(json.props.theme, undefined)
   t.is(json.props.id, 'hello')
 })
 


### PR DESCRIPTION
- Uses `React.forwardRef`
- [x] Add tests for blacklisted props: `theme`