### PR TITLE
Convert alias value to PX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 .nyc_output
 coverage*
 site
+.vscode

--- a/src/space.js
+++ b/src/space.js
@@ -39,7 +39,7 @@ const getProperties = key => {
 
 const getValue = scale => n => {
   if (!num(n)) {
-    return scale[n] || n
+    return px(scale[n]) || n
   }
   const abs = Math.abs(n)
   const neg = isNegative(n)

--- a/test.js
+++ b/test.js
@@ -369,6 +369,18 @@ test('space handles null values in arrays', t => {
   })
 })
 
+test('space can handle alias values', t => {
+  const a = space({
+    m: 'large',
+    theme: {
+      space: {
+        large: 12
+      }
+    }
+  })
+  t.deepEqual(a, {margin: '12px'})
+})
+
 // width
 test('width returns percentage widths', t => {
   const a = width({width: 1 / 2})


### PR DESCRIPTION
I added the capability, to have aliases for the spacing, but it also needs to be converted to pixels, if its a number. So it can be defined the same as without aliases:

e.g. 
```
export const space = {
  none: 0,
  0: 0,
  xxs: 2,
  1: 2,
  xs: 4,
  2: 4,
  s: 8,
  3: 8,
  m: 16,
  4: 16,
  l: 24,
  5: 24,
  xl: 32,
  6: 32,
};
```