### PR TITLE
Add some missing style props

### DIFF
--- a/docs/table.md
+++ b/docs/table.md
@@ -75,6 +75,7 @@ Function Name | Prop       | CSS Property    | Theme Field
 `gridAutoColumns` | `gridAutoColumns` | `grid-auto-columns` | none
 `gridTemplateRows` | `gridTemplateRows` | `grid-template-rows` | none
 `gridTemplateColumns` | `gridTemplateColumns` | `grid-template-columns` | none
+`gridTemplateAreas` | `gridTemplateAreas` | `grid-template-areas` | none
 
 ## Background
 

--- a/docs/table.md
+++ b/docs/table.md
@@ -54,6 +54,7 @@ Function Name | Prop       | CSS Property    | Theme Field
 `flexDirection` | `flexDirection` | `flex-direction` | none
 `flex` | `flex` | `flex` (shorthand) | none
 `alignContent`  | `alignContent` | `align-content` | none
+`justifyItems`  | `justifyItems` | `justify-items` | none
 `justifySelf` | `justifySelf` | `justify-self` | none
 `alignSelf` | `alignSelf` | `align-self` | none
 `order` | `order` | `order` | none
@@ -68,6 +69,7 @@ Function Name | Prop       | CSS Property    | Theme Field
 `gridColumnGap` | `gridColumnGap` | `grid-column-gap` | `space`
 `gridColumn` | `gridColumn` | `grid-column` | none
 `gridRow` | `gridRow` | `grid-row` | none
+`gridArea` | `gridArea` | `grid-area` | none
 `gridAutoFlow` | `gridAutoFlow` | `grid-auto-flow` | none
 `gridAutoRows` | `gridAutoRows` | `grid-auto-rows` | none
 `gridAutoColumns` | `gridAutoColumns` | `grid-auto-columns` | none
@@ -97,6 +99,7 @@ Function Name | Prop       | CSS Property    | Theme Field
 `borders` | `borderLeft` | `border-left` | `borders`
 `boxShadow` | `boxShadow` | `box-shadow` | `shadows`
 `opacity`   | `opacity` `o` | `opacity`  | `opacity`
+`overflow` | `overflow` | `overflow` | none
 
 ## Position
 

--- a/docs/table.md
+++ b/docs/table.md
@@ -28,6 +28,7 @@ Function Name | Prop       | CSS Property    | Theme Field
 `textAlign`   | `textAlign`    | `text-align`   | none
 `lineHeight`  | `lineHeight` | `line-height` | `lineHeights`
 `fontWeight`  | `fontWeight` | `font-weight` | `fontWeights`
+`fontStyle`  | `fontStyle` | `font-style` | none
 `letterSpacing` | `letterSpacing` | `letter-spacing` | `letterSpacings`
 
 ## Layout

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ export {
   // flexbox
   alignItems,
   alignContent,
+  justifyItems,
   justifyContent,
   flexWrap,
   flexDirection,
@@ -52,6 +53,8 @@ export {
   gridAutoRows,
   gridTemplateColumns,
   gridTemplateRows,
+  gridTemplateAreas,
+  gridArea,
   // borders
   border,
   borderTop,
@@ -64,6 +67,7 @@ export {
   // misc
   boxShadow,
   opacity,
+  overflow,
   background,
   backgroundImage,
   backgroundSize,

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,6 @@
-export * as util from './util'
-export * as styles from './styles'
-export {
-  style,
-  themeGet,
-  merge,
-  compose,
-} from './util'
+export * as util from "./util"
+export * as styles from "./styles"
+export { style, themeGet, merge, compose } from "./util"
 
 export {
   space,
@@ -19,6 +14,7 @@ export {
   textAlign,
   lineHeight,
   fontWeight,
+  fontStyle,
   letterSpacing,
   // layout
   display,
@@ -84,12 +80,12 @@ export {
   textStyle,
   colorStyle,
   buttonStyle,
-} from './styles'
+} from "./styles"
 
 // new
-export { default as variant } from './variant'
-export { default as mixed } from './mixed'
+export { default as variant } from "./variant"
+export { default as mixed } from "./mixed"
 
 // aliases for v2 api
-export { style as responsiveStyle } from './util'
-export { default as complexStyle } from './variant'
+export { style as responsiveStyle } from "./util"
+export { default as complexStyle } from "./variant"

--- a/src/styles.js
+++ b/src/styles.js
@@ -68,6 +68,10 @@ export const fontWeight = style({
   key: 'fontWeights'
 })
 
+export const fontStyle = style({
+  prop: 'fontStyle'
+})
+
 export const letterSpacing = style({
   prop: 'letterSpacing',
   key: 'letterSpacings',

--- a/src/styles.js
+++ b/src/styles.js
@@ -153,6 +153,10 @@ export const alignContent = style({
   prop: 'alignContent'
 })
 
+export const justifyItems = style({
+  prop: 'justifyItems'
+})
+
 export const justifyContent = style({
   prop: 'justifyContent'
 })
@@ -234,6 +238,14 @@ export const gridTemplateRows = style({
   prop: 'gridTemplateRows'
 })
 
+export const gridTemplateAreas = style({
+  prop: 'gridTemplateAreas'
+})
+
+export const gridArea = style({
+  prop: 'gridArea'
+})
+
 // borders
 const getBorder = n => num(n) && n > 0 ? n + 'px solid' : n
 
@@ -293,6 +305,10 @@ export const boxShadow = style({
 
 export const opacity = style({
   prop: 'opacity'
+})
+
+export const overflow = style({
+  prop: 'overflow'
 })
 
 // backgrounds

--- a/system-components/package.json
+++ b/system-components/package.json
@@ -44,6 +44,7 @@
     "roots": [
       "<rootDir>"
     ],
+    "testURL": "http://localhost",
     "testMatch": [
       "**/test.js"
     ],


### PR DESCRIPTION
This adds `fontStyle`, `overflow`, `justifyItems`, `gridTemlateAreas`, and `gridArea`.

Closes #240 

If you want me to rebuild the docs for this PR, I can do so.