### PR TITLE
System component blacklist fix

### DIFF
--- a/system-components/package.json
+++ b/system-components/package.json
@@ -41,6 +41,7 @@
     "styled-components": "^3.3.2"
   },
   "jest": {
+    "testURL": "http://localhost/",
     "roots": [
       "<rootDir>"
     ],

--- a/system-components/src/System.js
+++ b/system-components/src/System.js
@@ -83,11 +83,11 @@ class System {
       const baseProps = util.get(defaultProps, 'is.defaultProps') || {}
       Component.defaultProps = {
         ...baseProps,
+        ...defaultProps,
         blacklist: [
           ...blacklist,
           ...(baseProps.blacklist || [])
         ],
-        ...defaultProps
       }
       Component.propTypes = propTypes
       Component.systemComponent = true

--- a/system-components/test.js
+++ b/system-components/test.js
@@ -193,6 +193,18 @@ describe('system-components', () => {
     expect(json).toHaveStyleRule('color', 'tomato')
   })
 
+  test('extends a non-system component and apply blacklist', () => {
+    const Base = (props) => <div {...props} />
+    const Ext = system({
+      // is: Base, FIXME: this won't pass test
+      blacklist: ['customProp']
+    }, 'color')
+    const json = render(<Ext is={Base} customProp='hi' bg='tomato' />).toJSON()
+    expect(json).toHaveStyleRule('background-color', 'tomato')
+    expect(json.props.customProp).toBe(undefined)
+    expect(json.props.bg).toBe(undefined)
+  })
+
   test('passes innerRef to underlying element', () => {
     const Base = system({ p: 3 })
     let foo = 'hello'

--- a/system-components/test.js
+++ b/system-components/test.js
@@ -87,6 +87,15 @@ describe('system-components', () => {
     expect(json.props.customProp).toBe(undefined)
   })
 
+  test('blacklist options merge builtin settings', () => {
+    const Box = system({
+      blacklist: ['customProp']
+    }, 'space')
+    const json = render(<Box m='10' customProp='hi' />).toJSON()
+    expect(json.props.customProp).toBe(undefined)
+    expect(json.props.m).toBe(undefined)
+  })
+
   test('accepts an `is` prop to change the underlying DOM element', () => {
     const Box = system({
       p: 2


### PR DESCRIPTION
This PR is tried to resolve https://github.com/jxnblk/styled-system/issues/241

Also note that I added one more test case for extend non-system component. Pass the non-system component to defaultProps still failed. I could fix this, but the fixes will break another test 
```javascript
  test('extends a non-system component and does not accept an is prop', ...)
```
I am not sure whether it is designed by purpose this way.. IMHO this test should be removed ...

right now to extend component, best pass custom component during rendering rather than default option, and everything works fine
```jsx
render(<Ext is={(props) => <div {...props} />} customProp='hi' bg='tomato' />)
```

