### PR TITLE
[WIP] Prevent double rendering via the "is" prop in system-components

### DIFF
--- a/system-components/src/System.js
+++ b/system-components/src/System.js
@@ -76,7 +76,11 @@ class System {
         ...(defaultProps ? defaultProps.blacklist || [] : [])
       ]
 
-      const Base = defaultProps && typeof defaultProps.is === 'function' ? defaultProps.is : tag
+      let Base = tag
+      if (defaultProps && typeof defaultProps.is === 'function') {
+        Base = defaultProps.is
+        delete defaultProps.is
+      }
 
       const Component = createComponent(Base)(css, ...funcs)
 


### PR DESCRIPTION
We've run into issues using system-components if the component we pass via `defaultProps.is` respects the `is` prop itself:

```jsx
function Component({is: Tag = 'div', ...rest}) {
  return <Tag {...rest} />
}

export default system({is: Component}, 'space')
```

If you were to then instantiate this component _without_ setting the `is` prop:

```jsx
<Component />
```

then the `Component` function would actually be called _twice_:

1. the first time, it would be called as `Component({is: Component})`
1. the second, it would be called as `Component({is: 'p'})`

The simple/dumb fix here is to just `delete defaultProps.is` if it's a function. What would be smarter, though, would be to respect the _component's_ `defaultProps.is` and pass that along if it existed:

```js
const Base = tag
if (defaultProps && typeof defaultProps.is === 'function') {
  Base = defaultProps.is
  const defaultIs = get(Base, 'defaultProps.is')
  if (defaultIs) {
    defaultProps.is = defaultIs
  } else {
    delete defaultProps.is
  }
}
```

@jxnblk what do you think? Should I make that edit? Worth adding a failing test case first?