### PR TITLE
React Native: Avoid adding px to unit values

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -14,10 +14,11 @@ export const propTypes = {
   ]),
 }
 
+export const isReactNative = () => typeof navigator != 'undefined' && navigator.product == 'ReactNative'
 export const defaultBreakpoints = [ 40, 52, 64, ].map(n => n + 'em')
 export const is = n => n !== undefined && n !== null
 export const num = n => typeof n === 'number' && !isNaN(n)
-export const px = n => num(n) ? n + 'px' : n
+export const px = n => (isReactNative() ? n : num(n) ? n + 'px' : n)
 
 export const get = (obj, ...paths) => paths.join('.').split('.')
   .reduce((a, b) => (a && a[b]) ? a[b] : null, obj)


### PR DESCRIPTION
# What
Removes `px` units when using with React Native.

# Why
React Native does not accept `px` as unit values.

<img width="487" alt="screen shot 2018-09-05 at 19 09 14" src="https://user-images.githubusercontent.com/3157426/45129313-3c26d000-b140-11e8-8d33-3adf067f4717.png">

# How
Based on [this comment](https://github.com/jxnblk/styled-system/issues/142#issuecomment-386592680) from #142, I've just added an environment check on the `px` function and if the user is using React Native, then return without adding the `px` suffix.