### PR TITLE
🐛 Default media query to px if breakpoint value is unitless

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export const compose = (...funcs) => {
   return fn
 }
 
-export const createMediaQuery = n => `@media screen and (min-width: ${n})`
+export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`
 
 export const style = ({
   prop,


### PR DESCRIPTION
Fix #248 

The PR restores `createMediaQuery` behaviour to leverage `px` helper to supply default units as `px` when breakpoint value is unitless.