### PR TITLE
Don't run CI on docs/examples dir changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: node_js
 node_js:
   - 10
+  before_install:
+  - |
+      if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+        TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+      fi
+      git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(^(docs|examples))/' || {
+        echo "Stopping build process: /docs or /examples changes only."
+        exit
+      }
 install:
   - npm i
   - npm run pkg:prepare


### PR DESCRIPTION
Fixes #149 

Exit build process if only `/docs` or `/examples` changes.
Based on the findings from @macklinu