### PR TITLE
Possibility for providing a unitless breakpoints array and a unit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,11 @@ export const compose = (...funcs) => {
 
 export const createMediaQuery = n => `@media screen and (min-width: ${n})`
 
+const createMediaQueryWithUnit = breakpointsUnit => {
+  const unit = breakpointsUnit || '';
+  return n => `@media screen and (min-width: ${n}${unit})`;
+}
+
 export const style = ({
   prop,
   cssProperty,
@@ -74,12 +79,13 @@ export const style = ({
     if (!Array.isArray(val)) {
       return style(val)
     }
+    const breakpointsUnit = get(props.theme, 'breakpointsUnit');
 
     // how to hoist this up??
     const breakpoints = [
       null,
       ...(get(props.theme, 'breakpoints') || defaultBreakpoints)
-        .map(createMediaQuery)
+        .map(createMediaQueryWithUnit(breakpointsUnit))
     ]
 
     let styles = {}
@@ -201,10 +207,12 @@ export const space = props => {
         return style(value)
       }
 
+      const breakpointsUnit = get(props.theme, 'breakpointsUnit');
+
       const breakpoints = [
         null,
         ...(get(props.theme, 'breakpoints') || defaultBreakpoints)
-          .map(createMediaQuery)
+          .map(createMediaQueryWithUnit(breakpointsUnit))
       ]
 
       let styles = {}


### PR DESCRIPTION
This is an alternative to https://github.com/jxnblk/styled-system/pull/294 and gives an alternative solution to https://github.com/jxnblk/styled-system/issues/248

It adds an ability to provide new `breakpointsUnit` field in `theme` and have a unitless `breakpoints` array. These two are equivalent:
```jsx
<ThemeProvider theme={{ breakpoints: [ 480, 800, 1000 ], breakpointsUnit: 'px' }}>
    ...
</ThemeProvider>
```
```jsx
<ThemeProvider theme={{ breakpoints: [ '480px', '800px', '1000px' ] }}>
    ...
</ThemeProvider>
```

This allows you to reuse the breakpoints and perform calculations on them without using `parseInt` to get a numeric value.

