### PR TITLE
Support for breakpoint maps (objects)?

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,6 +204,22 @@ All styled-system functions accept arrays as values to set styles responsively u
 <Text fontSize={[ 3, 4, 5 ]} />
 ```
 
+Alternatively if you define your theme breakpoints as an `object` you can use the following syntax:
+
+```jsx
+<Box
+  width={{
+    sm: 1,
+    md: 1/2,
+    lg: 1/4
+  }}
+>
+</Box>
+```
+
+Read the [Responsive Styles][] docs for more information.
+
 [styled-components]: https://github.com/styled-components/styled-components
 [emotion]: https://github.com/emotion-js/emotion
 [glamorous]: https://github.com/paypal/glamorous
+[Responsive Styles]: https://github.com/jxnblk/styled-system/blob/master/docs/responsive-styles.md

--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -28,3 +28,35 @@ All style utilities add props that accept arrays as values for mobile-first resp
 <Box p={[ 1, 2, 3, 4 ]} />
 ```
 
+
+## Using objects
+
+Alternatively you can define your breakpoints as an `object` e.g.
+
+```jsx
+// theme.js
+export default {
+  breakpoints: {
+    sm: 0,    // zero represents the default (for mobile-first approach)
+    md: '48em',
+    lg: '80em'
+  }
+}
+```
+
+And then pass an `object` to configure how the component should respond at these breakpoints:
+
+```jsx
+<Box
+  width={{
+    sm: 1,    // 100% by default (no media query)
+    md: 1/2,  // 50% at 'md' (48em and up)
+    lg: 1/4   // 25% at 'lg' (80em and up)
+  }}
+/>
+```
+
+Note: it isn't necessary to set a value for each breakpoint. The following would only apply 50% width at the `md` breakpoint:
+
+```jsx
+<Box width={{ md: 1/2 }} />

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "prepare": "npm run clean && npm run build:cjs && npm run build:esm",
     "clean": "rm -rf dist && mkdir dist",
-    "build:cjs": "cross-env NODE_ENV=cjs babel src -o dist/index.cjs.js --source-maps",
-    "build:esm": "cross-env NODE_ENV=esm babel src -o dist/index.esm.js --source-maps",
+    "build:cjs": "cross-env NODE_ENV=cjs babel src -o dist/index.cjs.js",
+    "build:esm": "cross-env NODE_ENV=esm babel src -o dist/index.esm.js",
     "start": "mdx-go docs",
     "docs": "mdx-go build docs -d site",
     "logo": "npx repng docs/Logo.js -d docs -f logo.png -w 512 -h 512 -p '{\"size\":512}'",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "prepare": "npm run clean && npm run build:cjs && npm run build:esm",
     "clean": "rm -rf dist && mkdir dist",
-    "build:cjs": "cross-env NODE_ENV=cjs babel src -o dist/index.cjs.js",
-    "build:esm": "cross-env NODE_ENV=esm babel src -o dist/index.esm.js",
+    "build:cjs": "cross-env NODE_ENV=cjs babel src -o dist/index.cjs.js --source-maps",
+    "build:esm": "cross-env NODE_ENV=esm babel src -o dist/index.esm.js --source-maps",
     "start": "mdx-go docs",
     "docs": "mdx-go build docs -d site",
     "logo": "npx repng docs/Logo.js -d docs -f logo.png -w 512 -h 512 -p '{\"size\":512}'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "npm run clean && npm run build:cjs && npm run build:esm",
-    "prettier": "prettier \"{src,test}/**/*.js\"",
+    "prettier": "prettier \"{src,test}/**/*.js\" --write",
     "clean": "rm -rf dist && mkdir dist",
     "build:cjs": "cross-env NODE_ENV=cjs babel src -o dist/index.cjs.js",
     "build:esm": "cross-env NODE_ENV=esm babel src -o dist/index.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ const getStyles = ({ props, style, value }) => {
   for (let breakpoint in value) {
     const minWidth = breakpoints[breakpoint]
     if (!minWidth) {
-      styles = Object.assign({}, styles, style(value[breakpoint]))
+      styles = Object.assign(styles, style(value[breakpoint]))
     } else {
       const rule = style(value[breakpoint])
       const media = createMediaQuery(minWidth)

--- a/src/index.js
+++ b/src/index.js
@@ -1,91 +1,99 @@
-import PropTypes from 'prop-types'
+import PropTypes from "prop-types";
 
 // utils
-const noop = n => n
+const noop = n => n;
 
 export const propTypes = {
-  numberOrString: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]),
+  numberOrString: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   responsive: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
-    PropTypes.array,
-  ]),
-}
+    PropTypes.array
+  ])
+};
 
-export const defaultBreakpoints = [ 40, 52, 64, ].map(n => n + 'em')
-export const is = n => n !== undefined && n !== null
-export const num = n => typeof n === 'number' && !isNaN(n)
-export const px = n => num(n) ? n + 'px' : n
-export const { isArray } = Array
-export const isObject = n => (typeof n === 'object' && n !== null)
+export const defaultBreakpoints = [40, 52, 64].map(n => n + "em");
+export const is = n => n !== undefined && n !== null;
+export const num = n => typeof n === "number" && !isNaN(n);
+export const px = n => (num(n) ? n + "px" : n);
+export const { isArray } = Array;
+export const isObject = n => typeof n === "object" && n !== null;
 
-export const get = (obj, ...paths) => paths.join('.').split('.')
-  .reduce((a, b) => (a && a[b]) ? a[b] : null, obj)
+export const get = (obj, ...paths) =>
+  paths
+    .join(".")
+    .split(".")
+    .reduce((a, b) => (a && a[b] ? a[b] : null), obj);
 
-export const themeGet = (paths, fallback) => props => get(props.theme, paths) || fallback
+export const themeGet = (paths, fallback) => props =>
+  get(props.theme, paths) || fallback;
 
-export const cloneFunc = fn => (...args) => fn(...args)
+export const cloneFunc = fn => (...args) => fn(...args);
 
-export const merge = (a, b) => Object.assign({}, a, b, Object
-  .keys(b || {}).reduce((obj, key) =>
-    Object.assign(obj, {
-      [key]: a[key] !== null && typeof a[key] === 'object'
-      ? merge(a[key], b[key])
-      : b[key]
-    }),
-    {}))
+export const merge = (a, b) =>
+  Object.assign(
+    {},
+    a,
+    b,
+    Object.keys(b || {}).reduce(
+      (obj, key) =>
+        Object.assign(obj, {
+          [key]:
+            a[key] !== null && typeof a[key] === "object"
+              ? merge(a[key], b[key])
+              : b[key]
+        }),
+      {}
+    )
+  );
 
 export const compose = (...funcs) => {
-  const fn = props => funcs
-    .map(fn => fn(props))
-    .filter(Boolean)
-    .reduce(merge, {})
+  const fn = props =>
+    funcs
+      .map(fn => fn(props))
+      .filter(Boolean)
+      .reduce(merge, {});
 
-  fn.propTypes = funcs
-    .map(fn => fn.propTypes)
-    .reduce(merge, {})
-  return fn
-}
+  fn.propTypes = funcs.map(fn => fn.propTypes).reduce(merge, {});
+  return fn;
+};
 
-export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`
+export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`;
 
 const getStyles = ({ props, style, value }) => {
   if (!isObject(value)) {
-    return style(value)
+    return style(value);
   }
 
   // how to hoist this up??
-  const breakpoints = get(props.theme, 'breakpoints') || defaultBreakpoints
-  
+  const breakpoints = get(props.theme, "breakpoints") || defaultBreakpoints;
+
   if (isArray(value)) {
-    const styles = style(value[0]) || {}
+    const styles = style(value[0]) || {};
     for (let i = 1; i < value.length; i++) {
-      const rule = style(value[i])
+      const rule = style(value[i]);
       if (rule) {
-        const media = createMediaQuery(breakpoints[i - 1])
-        styles[media] = rule
+        const media = createMediaQuery(breakpoints[i - 1]);
+        styles[media] = rule;
       }
     }
-    return styles
+    return styles;
   }
 
-  const styles = {}
+  const styles = {};
   for (let breakpoint in value) {
-    const minWidth = breakpoints[breakpoint]
+    const minWidth = breakpoints[breakpoint];
     if (!minWidth) {
-      Object.assign(styles, style(value[breakpoint]))
+      Object.assign(styles, style(value[breakpoint]));
     } else {
-      const rule = style(value[breakpoint])
-      const media = createMediaQuery(minWidth)
-      styles[media] = rule
+      const rule = style(value[breakpoint]);
+      const media = createMediaQuery(minWidth);
+      styles[media] = rule;
     }
   }
 
-  return styles
-}
+  return styles;
+};
 
 export const style = ({
   prop,
@@ -95,46 +103,44 @@ export const style = ({
   transformValue,
   scale: defaultScale = {}
 }) => {
-  const css = cssProperty || prop
-  const transform  = transformValue || getter || noop
+  const css = cssProperty || prop;
+  const transform = transformValue || getter || noop;
   const fn = props => {
-    const value = props[prop]
-    if (!is(value)) return null
+    const value = props[prop];
+    if (!is(value)) return null;
 
-    const scale = get(props.theme, key) || defaultScale
-    const style = n => is(n) ? ({
-      [css]: transform(
-        get(scale, n) || n
-      )
-    }) : null
+    const scale = get(props.theme, key) || defaultScale;
+    const style = n =>
+      is(n)
+        ? {
+            [css]: transform(get(scale, n) || n)
+          }
+        : null;
 
-    return getStyles({ props, style, value })
-  }
+    return getStyles({ props, style, value });
+  };
 
-  fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) }
+  fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) };
 
   fn.propTypes[prop].meta = {
     prop,
     themeKey: key,
-    styleType: 'responsive'
-  }
+    styleType: "responsive"
+  };
 
-  return fn
-}
+  return fn;
+};
 
-export const getWidth = n => !num(n) || n > 1 ? px(n) : (n * 100) + '%'
+export const getWidth = n => (!num(n) || n > 1 ? px(n) : n * 100 + "%");
 
 // variant
-export const variant = ({
-  key,
-  prop = 'variant'
-}) => {
-  const fn = (props) => get(props.theme, key, props[prop]) || null
+export const variant = ({ key, prop = "variant" }) => {
+  const fn = props => get(props.theme, key, props[prop]) || null;
   fn.propTypes = {
     [prop]: propTypes.numberOrString
-  }
-  return fn
-}
+  };
+  return fn;
+};
 
 export const util = {
   propTypes,
@@ -148,373 +154,369 @@ export const util = {
   merge,
   compose,
   createMediaQuery,
-  style,
-}
+  style
+};
 
 // space
-const isNegative = n => n < 0
-const REG = /^[mp][trblxy]?$/
+const isNegative = n => n < 0;
+const REG = /^[mp][trblxy]?$/;
 const properties = {
-  m: 'margin',
-  p: 'padding'
-}
+  m: "margin",
+  p: "padding"
+};
 const directions = {
-  t: 'Top',
-  r: 'Right',
-  b: 'Bottom',
-  l: 'Left',
-  x: [ 'Left', 'Right' ],
-  y: [ 'Top', 'Bottom' ],
-}
+  t: "Top",
+  r: "Right",
+  b: "Bottom",
+  l: "Left",
+  x: ["Left", "Right"],
+  y: ["Top", "Bottom"]
+};
 
 const getProperties = key => {
-  const [ a, b ] = key.split('')
-  const property = properties[a]
-  const direction = directions[b] || ''
+  const [a, b] = key.split("");
+  const property = properties[a];
+  const direction = directions[b] || "";
   return Array.isArray(direction)
     ? direction.map(dir => property + dir)
-    : [ property + direction ]
-}
+    : [property + direction];
+};
 
 const getValue = scale => n => {
   if (!num(n)) {
-    return px(scale[n] || n)
+    return px(scale[n] || n);
   }
-  const abs = Math.abs(n)
-  const neg = isNegative(n)
-  const value = scale[abs] || abs
+  const abs = Math.abs(n);
+  const neg = isNegative(n);
+  const value = scale[abs] || abs;
   if (!num(value)) {
-    return neg ? '-' + value : value
+    return neg ? "-" + value : value;
   }
-  return px(value * (neg ? -1 : 1))
-}
+  return px(value * (neg ? -1 : 1));
+};
 
-const defaultScale = [
-  0, 4, 8, 16, 32, 64, 128, 256, 512
-]
+const defaultScale = [0, 4, 8, 16, 32, 64, 128, 256, 512];
 
 export const space = props => {
   const keys = Object.keys(props)
     .filter(key => REG.test(key))
-    .sort()
-  const scale = get(props.theme, 'space') || defaultScale
-  const getStyle = getValue(scale)
+    .sort();
+  const scale = get(props.theme, "space") || defaultScale;
+  const getStyle = getValue(scale);
 
   return keys
     .map(key => {
-      const value = props[key]
-      const properties = getProperties(key)
+      const value = props[key];
+      const properties = getProperties(key);
 
-      const style = n => is(n) ? properties.reduce((a, prop) => ({
-        ...a,
-        [prop]: getStyle(n)
-      }), {}) : null
+      const style = n =>
+        is(n)
+          ? properties.reduce(
+              (a, prop) => ({
+                ...a,
+                [prop]: getStyle(n)
+              }),
+              {}
+            )
+          : null;
 
-      return getStyles({ props, style, value })
+      return getStyles({ props, style, value });
     })
-    .reduce(merge, {})
-}
+    .reduce(merge, {});
+};
 
 space.propTypes = {
-  m:  cloneFunc(propTypes.responsive),
+  m: cloneFunc(propTypes.responsive),
   mt: cloneFunc(propTypes.responsive),
   mr: cloneFunc(propTypes.responsive),
   mb: cloneFunc(propTypes.responsive),
   ml: cloneFunc(propTypes.responsive),
   mx: cloneFunc(propTypes.responsive),
   my: cloneFunc(propTypes.responsive),
-  p:  cloneFunc(propTypes.responsive),
+  p: cloneFunc(propTypes.responsive),
   pt: cloneFunc(propTypes.responsive),
   pr: cloneFunc(propTypes.responsive),
   pb: cloneFunc(propTypes.responsive),
   pl: cloneFunc(propTypes.responsive),
   px: cloneFunc(propTypes.responsive),
   py: cloneFunc(propTypes.responsive)
-}
+};
 
 const meta = prop => ({
   prop,
-  themeKey: 'space',
-  styleType: 'responsive'
-})
+  themeKey: "space",
+  styleType: "responsive"
+});
 
 Object.keys(space.propTypes).forEach(prop => {
-  space.propTypes[prop].meta = meta(prop)
-})
+  space.propTypes[prop].meta = meta(prop);
+});
 
 // styles
 export const width = style({
-  prop: 'width',
+  prop: "width",
   transformValue: getWidth
-})
+});
 
 export const fontSize = style({
-  prop: 'fontSize',
-  key: 'fontSizes',
+  prop: "fontSize",
+  key: "fontSizes",
   transformValue: px,
-  scale: [
-    12,
-    14,
-    16,
-    20,
-    24,
-    32,
-    48,
-    64,
-    72
-  ]
-})
+  scale: [12, 14, 16, 20, 24, 32, 48, 64, 72]
+});
 
 export const textColor = style({
-  prop: 'color',
-  key: 'colors',
-})
+  prop: "color",
+  key: "colors"
+});
 
 export const bgColor = style({
-  prop: 'bg',
-  cssProperty: 'backgroundColor',
-  key: 'colors'
-})
+  prop: "bg",
+  cssProperty: "backgroundColor",
+  key: "colors"
+});
 
 export const color = compose(
   textColor,
   bgColor
-)
+);
 
 // typography
 export const fontFamily = style({
-  prop: 'fontFamily',
-  key: 'fonts'
-})
+  prop: "fontFamily",
+  key: "fonts"
+});
 
 export const textAlign = style({
-  prop: 'textAlign'
-})
+  prop: "textAlign"
+});
 
 export const lineHeight = style({
-  prop: 'lineHeight',
-  key: 'lineHeights'
-})
+  prop: "lineHeight",
+  key: "lineHeights"
+});
 
 export const fontWeight = style({
-  prop: 'fontWeight',
-  key: 'fontWeights'
-})
+  prop: "fontWeight",
+  key: "fontWeights"
+});
 
 export const fontStyle = style({
-  prop: 'fontStyle'
-})
+  prop: "fontStyle"
+});
 
 export const letterSpacing = style({
-  prop: 'letterSpacing',
-  key: 'letterSpacings',
+  prop: "letterSpacing",
+  key: "letterSpacings",
   transformValue: px
-})
+});
 
 // layout
 export const display = style({
-  prop: 'display'
-})
+  prop: "display"
+});
 
 export const maxWidth = style({
-  prop: 'maxWidth',
-  key: 'maxWidths',
+  prop: "maxWidth",
+  key: "maxWidths",
   transformValue: px
-})
+});
 
 export const minWidth = style({
-  prop: 'minWidth',
-  key: 'minWidths',
+  prop: "minWidth",
+  key: "minWidths",
   transformValue: px
-})
+});
 
 export const height = style({
-  prop: 'height',
-  key: 'heights',
+  prop: "height",
+  key: "heights",
   transformValue: px
-})
+});
 
 export const maxHeight = style({
-  prop: 'maxHeight',
-  key: 'maxHeights',
+  prop: "maxHeight",
+  key: "maxHeights",
   transformValue: px
-})
+});
 
 export const minHeight = style({
-  prop: 'minHeight',
-  key: 'minHeights',
+  prop: "minHeight",
+  key: "minHeights",
   transformValue: px
-})
+});
 
 export const sizeWidth = style({
-  prop: 'size',
-  cssProperty: 'width',
+  prop: "size",
+  cssProperty: "width",
   transformValue: px
-})
+});
 
 export const sizeHeight = style({
-  prop: 'size',
-  cssProperty: 'height',
+  prop: "size",
+  cssProperty: "height",
   transformValue: px
-})
+});
 
 export const size = compose(
   sizeHeight,
   sizeWidth
-)
+);
 
 export const ratioPadding = style({
-  prop: 'ratio',
-  cssProperty: 'paddingBottom',
-  transformValue: n => (n * 100) + '%'
-})
+  prop: "ratio",
+  cssProperty: "paddingBottom",
+  transformValue: n => n * 100 + "%"
+});
 
-export const ratio = props => props.ratio ? ({
-  height: 0,
-  ...ratioPadding(props)
-}) : null
+export const ratio = props =>
+  props.ratio
+    ? {
+        height: 0,
+        ...ratioPadding(props)
+      }
+    : null;
 ratio.propTypes = {
   ...ratioPadding.propTypes
-}
+};
 
 export const verticalAlign = style({
-  prop: 'verticalAlign'
-})
+  prop: "verticalAlign"
+});
 
 // flexbox
 export const alignItems = style({
-  prop: 'alignItems'
-})
+  prop: "alignItems"
+});
 
 export const alignContent = style({
-  prop: 'alignContent'
-})
+  prop: "alignContent"
+});
 
 export const justifyItems = style({
-  prop: 'justifyItems'
-})
+  prop: "justifyItems"
+});
 
 export const justifyContent = style({
-  prop: 'justifyContent'
-})
+  prop: "justifyContent"
+});
 
 export const flexWrap = style({
-  prop: 'flexWrap'
-})
+  prop: "flexWrap"
+});
 
 export const flexBasis = style({
-  prop: 'flexBasis',
+  prop: "flexBasis",
   transformValue: getWidth
-})
-
+});
 
 export const flexDirection = style({
-  prop: 'flexDirection'
-})
+  prop: "flexDirection"
+});
 
 export const flex = style({
-  prop: 'flex'
-})
+  prop: "flex"
+});
 
 export const justifySelf = style({
-  prop: 'justifySelf'
-})
+  prop: "justifySelf"
+});
 
 export const alignSelf = style({
-  prop: 'alignSelf'
-})
+  prop: "alignSelf"
+});
 
 export const order = style({
-  prop: 'order'
-})
+  prop: "order"
+});
 
 // grid
 export const gridGap = style({
-  prop: 'gridGap',
+  prop: "gridGap",
   transformValue: px,
-  key: 'space'
-})
+  key: "space"
+});
 
 export const gridColumnGap = style({
-  prop: 'gridColumnGap',
+  prop: "gridColumnGap",
   transformValue: px,
-  key: 'space'
-})
+  key: "space"
+});
 
 export const gridRowGap = style({
-  prop: 'gridRowGap',
+  prop: "gridRowGap",
   transformValue: px,
-  key: 'space'
-})
+  key: "space"
+});
 
 export const gridColumn = style({
-  prop: 'gridColumn'
-})
+  prop: "gridColumn"
+});
 
 export const gridRow = style({
-  prop: 'gridRow'
-})
+  prop: "gridRow"
+});
 
 export const gridAutoFlow = style({
-  prop: 'gridAutoFlow'
-})
+  prop: "gridAutoFlow"
+});
 
 export const gridAutoColumns = style({
-  prop: 'gridAutoColumns'
-})
+  prop: "gridAutoColumns"
+});
 
 export const gridAutoRows = style({
-  prop: 'gridAutoRows'
-})
+  prop: "gridAutoRows"
+});
 
 export const gridTemplateColumns = style({
-  prop: 'gridTemplateColumns'
-})
+  prop: "gridTemplateColumns"
+});
 
 export const gridTemplateRows = style({
-  prop: 'gridTemplateRows'
-})
+  prop: "gridTemplateRows"
+});
 
 export const gridTemplateAreas = style({
-  prop: 'gridTemplateAreas'
-})
+  prop: "gridTemplateAreas"
+});
 
 export const gridArea = style({
-  prop: 'gridArea'
-})
+  prop: "gridArea"
+});
 
 // borders
-const getBorder = n => num(n) && n > 0 ? n + 'px solid' : n
+const getBorder = n => (num(n) && n > 0 ? n + "px solid" : n);
 
 export const border = style({
-  prop: 'border',
-  key: 'borders',
+  prop: "border",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borderTop = style({
-  prop: 'borderTop',
-  key: 'borders',
+  prop: "borderTop",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borderRight = style({
-  prop: 'borderRight',
-  key: 'borders',
+  prop: "borderRight",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borderBottom = style({
-  prop: 'borderBottom',
-  key: 'borders',
+  prop: "borderBottom",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borderLeft = style({
-  prop: 'borderLeft',
-  key: 'borders',
+  prop: "borderLeft",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borders = compose(
   border,
@@ -522,96 +524,95 @@ export const borders = compose(
   borderRight,
   borderBottom,
   borderLeft
-)
+);
 
 export const borderColor = style({
-  prop: 'borderColor',
-  key: 'colors'
-})
+  prop: "borderColor",
+  key: "colors"
+});
 
 export const borderRadius = style({
-  prop: 'borderRadius',
-  key: 'radii',
-  transformValue: px,
-})
+  prop: "borderRadius",
+  key: "radii",
+  transformValue: px
+});
 
 export const boxShadow = style({
-  prop: 'boxShadow',
-  key: 'shadows'
-})
+  prop: "boxShadow",
+  key: "shadows"
+});
 
 export const opacity = style({
-  prop: 'opacity'
-})
+  prop: "opacity"
+});
 
 export const overflow = style({
-  prop: 'overflow'
-})
+  prop: "overflow"
+});
 
 // backgrounds
 export const background = style({
-  prop: 'background'
-})
+  prop: "background"
+});
 
 export const backgroundImage = style({
-  prop: 'backgroundImage'
-})
+  prop: "backgroundImage"
+});
 
 export const backgroundSize = style({
-  prop: 'backgroundSize'
-})
+  prop: "backgroundSize"
+});
 
 export const backgroundPosition = style({
-  prop: 'backgroundPosition'
-})
+  prop: "backgroundPosition"
+});
 
 export const backgroundRepeat = style({
-  prop: 'backgroundRepeat'
-})
+  prop: "backgroundRepeat"
+});
 
 // position
 export const position = style({
-  prop: 'position'
-})
+  prop: "position"
+});
 
 export const zIndex = style({
-  prop: 'zIndex'
-})
+  prop: "zIndex"
+});
 
 export const top = style({
-  prop: 'top',
+  prop: "top",
   transformValue: px
-})
+});
 
 export const right = style({
-  prop: 'right',
+  prop: "right",
   transformValue: px
-})
+});
 
 export const bottom = style({
-  prop: 'bottom',
+  prop: "bottom",
   transformValue: px
-})
+});
 
 export const left = style({
-  prop: 'left',
+  prop: "left",
   transformValue: px
-})
-
+});
 
 export const textStyle = variant({
-  prop: 'textStyle',
-  key: 'textStyles'
-})
+  prop: "textStyle",
+  key: "textStyles"
+});
 
 export const colorStyle = variant({
-  prop: 'colors',
-  key: 'colorStyles',
-})
+  prop: "colors",
+  key: "colorStyles"
+});
 
 export const buttonStyle = variant({
-  key: 'buttons'
-})
+  key: "buttons"
+});
 
 export const styles = {
   space,
@@ -686,29 +687,27 @@ export const styles = {
   left,
   textStyle,
   colorStyle,
-  buttonStyle,
-}
+  buttonStyle
+};
 
 // mixed
 const omit = (obj, blacklist) => {
-  const next = {}
+  const next = {};
   for (let key in obj) {
-    if (blacklist.indexOf(key) > -1) continue
-    next[key] = obj[key]
+    if (blacklist.indexOf(key) > -1) continue;
+    next[key] = obj[key];
   }
-  return next
-}
+  return next;
+};
 
 const funcs = Object.keys(styles)
   .map(key => styles[key])
-  .filter(fn => typeof fn === 'function')
+  .filter(fn => typeof fn === "function");
 
-const blacklist = funcs.reduce((a, fn) => [
-  ...a,
-  ...Object.keys(fn.propTypes || {})
-], [ 'theme' ])
+const blacklist = funcs.reduce(
+  (a, fn) => [...a, ...Object.keys(fn.propTypes || {})],
+  ["theme"]
+);
 
-
-export const mixed = props => funcs
-  .map(fn => fn(props))
-  .reduce(merge, omit(props, blacklist))
+export const mixed = props =>
+  funcs.map(fn => fn(props)).reduce(merge, omit(props, blacklist));

--- a/src/index.js
+++ b/src/index.js
@@ -72,16 +72,18 @@ const getStyles = (props, style, val) => {
     return styles
   }
 
-  if (isArray(breakpoints)) return null
-
-  const styles = style(val.def) || {}
+  let styles = {}
   for (let breakpoint in val) {
-    if (breakpoints[breakpoint]) {
+    const minWidth = breakpoints[breakpoint]
+    if (!minWidth) {
+      styles = { ...styles, ...style(val[breakpoint]) }
+    } else {
       const rule = style(val[breakpoint])
-      const media = createMediaQuery(breakpoints[breakpoint])
+      const media = createMediaQuery(minWidth)
       styles[media] = rule
     }
   }
+
   return styles
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,11 +72,11 @@ const getStyles = ({ props, style, value }) => {
     return styles
   }
 
-  let styles = {}
+  const styles = {}
   for (let breakpoint in value) {
     const minWidth = breakpoints[breakpoint]
     if (!minWidth) {
-      styles = Object.assign(styles, style(value[breakpoint]))
+      Object.assign(styles, style(value[breakpoint]))
     } else {
       const rule = style(value[breakpoint])
       const media = createMediaQuery(minWidth)

--- a/src/index.js
+++ b/src/index.js
@@ -1,34 +1,34 @@
-import PropTypes from "prop-types";
+import PropTypes from 'prop-types'
 
 // utils
-const noop = n => n;
+const noop = n => n
 
 export const propTypes = {
   numberOrString: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   responsive: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
-    PropTypes.array
-  ])
-};
+    PropTypes.array,
+  ]),
+}
 
-export const defaultBreakpoints = [40, 52, 64].map(n => n + "em");
-export const is = n => n !== undefined && n !== null;
-export const num = n => typeof n === "number" && !isNaN(n);
-export const px = n => (num(n) ? n + "px" : n);
-export const { isArray } = Array;
-export const isObject = n => typeof n === "object" && n !== null;
+export const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
+export const is = n => n !== undefined && n !== null
+export const num = n => typeof n === 'number' && !isNaN(n)
+export const px = n => (num(n) ? n + 'px' : n)
+export const { isArray } = Array
+export const isObject = n => typeof n === 'object' && n !== null
 
 export const get = (obj, ...paths) =>
   paths
-    .join(".")
-    .split(".")
-    .reduce((a, b) => (a && a[b] ? a[b] : null), obj);
+    .join('.')
+    .split('.')
+    .reduce((a, b) => (a && a[b] ? a[b] : null), obj)
 
 export const themeGet = (paths, fallback) => props =>
-  get(props.theme, paths) || fallback;
+  get(props.theme, paths) || fallback
 
-export const cloneFunc = fn => (...args) => fn(...args);
+export const cloneFunc = fn => (...args) => fn(...args)
 
 export const merge = (a, b) =>
   Object.assign(
@@ -39,61 +39,61 @@ export const merge = (a, b) =>
       (obj, key) =>
         Object.assign(obj, {
           [key]:
-            a[key] !== null && typeof a[key] === "object"
+            a[key] !== null && typeof a[key] === 'object'
               ? merge(a[key], b[key])
-              : b[key]
+              : b[key],
         }),
       {}
     )
-  );
+  )
 
 export const compose = (...funcs) => {
   const fn = props =>
     funcs
       .map(fn => fn(props))
       .filter(Boolean)
-      .reduce(merge, {});
+      .reduce(merge, {})
 
-  fn.propTypes = funcs.map(fn => fn.propTypes).reduce(merge, {});
-  return fn;
-};
+  fn.propTypes = funcs.map(fn => fn.propTypes).reduce(merge, {})
+  return fn
+}
 
-export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`;
+export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`
 
 const getStyles = ({ props, style, value }) => {
   if (!isObject(value)) {
-    return style(value);
+    return style(value)
   }
 
   // how to hoist this up??
-  const breakpoints = get(props.theme, "breakpoints") || defaultBreakpoints;
+  const breakpoints = get(props.theme, 'breakpoints') || defaultBreakpoints
 
   if (isArray(value)) {
-    const styles = style(value[0]) || {};
+    const styles = style(value[0]) || {}
     for (let i = 1; i < value.length; i++) {
-      const rule = style(value[i]);
+      const rule = style(value[i])
       if (rule) {
-        const media = createMediaQuery(breakpoints[i - 1]);
-        styles[media] = rule;
+        const media = createMediaQuery(breakpoints[i - 1])
+        styles[media] = rule
       }
     }
-    return styles;
+    return styles
   }
 
-  const styles = {};
+  const styles = {}
   for (let breakpoint in value) {
-    const minWidth = breakpoints[breakpoint];
+    const minWidth = breakpoints[breakpoint]
     if (!minWidth) {
-      Object.assign(styles, style(value[breakpoint]));
+      Object.assign(styles, style(value[breakpoint]))
     } else {
-      const rule = style(value[breakpoint]);
-      const media = createMediaQuery(minWidth);
-      styles[media] = rule;
+      const rule = style(value[breakpoint])
+      const media = createMediaQuery(minWidth)
+      styles[media] = rule
     }
   }
 
-  return styles;
-};
+  return styles
+}
 
 export const style = ({
   prop,
@@ -101,46 +101,46 @@ export const style = ({
   key,
   getter,
   transformValue,
-  scale: defaultScale = {}
+  scale: defaultScale = {},
 }) => {
-  const css = cssProperty || prop;
-  const transform = transformValue || getter || noop;
+  const css = cssProperty || prop
+  const transform = transformValue || getter || noop
   const fn = props => {
-    const value = props[prop];
-    if (!is(value)) return null;
+    const value = props[prop]
+    if (!is(value)) return null
 
-    const scale = get(props.theme, key) || defaultScale;
+    const scale = get(props.theme, key) || defaultScale
     const style = n =>
       is(n)
         ? {
-            [css]: transform(get(scale, n) || n)
+            [css]: transform(get(scale, n) || n),
           }
-        : null;
+        : null
 
-    return getStyles({ props, style, value });
-  };
+    return getStyles({ props, style, value })
+  }
 
-  fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) };
+  fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) }
 
   fn.propTypes[prop].meta = {
     prop,
     themeKey: key,
-    styleType: "responsive"
-  };
+    styleType: 'responsive',
+  }
 
-  return fn;
-};
+  return fn
+}
 
-export const getWidth = n => (!num(n) || n > 1 ? px(n) : n * 100 + "%");
+export const getWidth = n => (!num(n) || n > 1 ? px(n) : n * 100 + '%')
 
 // variant
-export const variant = ({ key, prop = "variant" }) => {
-  const fn = props => get(props.theme, key, props[prop]) || null;
+export const variant = ({ key, prop = 'variant' }) => {
+  const fn = props => get(props.theme, key, props[prop]) || null
   fn.propTypes = {
-    [prop]: propTypes.numberOrString
-  };
-  return fn;
-};
+    [prop]: propTypes.numberOrString,
+  }
+  return fn
+}
 
 export const util = {
   propTypes,
@@ -154,76 +154,76 @@ export const util = {
   merge,
   compose,
   createMediaQuery,
-  style
-};
+  style,
+}
 
 // space
-const isNegative = n => n < 0;
-const REG = /^[mp][trblxy]?$/;
+const isNegative = n => n < 0
+const REG = /^[mp][trblxy]?$/
 const properties = {
-  m: "margin",
-  p: "padding"
-};
+  m: 'margin',
+  p: 'padding',
+}
 const directions = {
-  t: "Top",
-  r: "Right",
-  b: "Bottom",
-  l: "Left",
-  x: ["Left", "Right"],
-  y: ["Top", "Bottom"]
-};
+  t: 'Top',
+  r: 'Right',
+  b: 'Bottom',
+  l: 'Left',
+  x: ['Left', 'Right'],
+  y: ['Top', 'Bottom'],
+}
 
 const getProperties = key => {
-  const [a, b] = key.split("");
-  const property = properties[a];
-  const direction = directions[b] || "";
+  const [a, b] = key.split('')
+  const property = properties[a]
+  const direction = directions[b] || ''
   return Array.isArray(direction)
     ? direction.map(dir => property + dir)
-    : [property + direction];
-};
+    : [property + direction]
+}
 
 const getValue = scale => n => {
   if (!num(n)) {
-    return px(scale[n] || n);
+    return px(scale[n] || n)
   }
-  const abs = Math.abs(n);
-  const neg = isNegative(n);
-  const value = scale[abs] || abs;
+  const abs = Math.abs(n)
+  const neg = isNegative(n)
+  const value = scale[abs] || abs
   if (!num(value)) {
-    return neg ? "-" + value : value;
+    return neg ? '-' + value : value
   }
-  return px(value * (neg ? -1 : 1));
-};
+  return px(value * (neg ? -1 : 1))
+}
 
-const defaultScale = [0, 4, 8, 16, 32, 64, 128, 256, 512];
+const defaultScale = [0, 4, 8, 16, 32, 64, 128, 256, 512]
 
 export const space = props => {
   const keys = Object.keys(props)
     .filter(key => REG.test(key))
-    .sort();
-  const scale = get(props.theme, "space") || defaultScale;
-  const getStyle = getValue(scale);
+    .sort()
+  const scale = get(props.theme, 'space') || defaultScale
+  const getStyle = getValue(scale)
 
   return keys
     .map(key => {
-      const value = props[key];
-      const properties = getProperties(key);
+      const value = props[key]
+      const properties = getProperties(key)
 
       const style = n =>
         is(n)
           ? properties.reduce(
               (a, prop) => ({
                 ...a,
-                [prop]: getStyle(n)
+                [prop]: getStyle(n),
               }),
               {}
             )
-          : null;
+          : null
 
-      return getStyles({ props, style, value });
+      return getStyles({ props, style, value })
     })
-    .reduce(merge, {});
-};
+    .reduce(merge, {})
+}
 
 space.propTypes = {
   m: cloneFunc(propTypes.responsive),
@@ -239,284 +239,284 @@ space.propTypes = {
   pb: cloneFunc(propTypes.responsive),
   pl: cloneFunc(propTypes.responsive),
   px: cloneFunc(propTypes.responsive),
-  py: cloneFunc(propTypes.responsive)
-};
+  py: cloneFunc(propTypes.responsive),
+}
 
 const meta = prop => ({
   prop,
-  themeKey: "space",
-  styleType: "responsive"
-});
+  themeKey: 'space',
+  styleType: 'responsive',
+})
 
 Object.keys(space.propTypes).forEach(prop => {
-  space.propTypes[prop].meta = meta(prop);
-});
+  space.propTypes[prop].meta = meta(prop)
+})
 
 // styles
 export const width = style({
-  prop: "width",
-  transformValue: getWidth
-});
+  prop: 'width',
+  transformValue: getWidth,
+})
 
 export const fontSize = style({
-  prop: "fontSize",
-  key: "fontSizes",
+  prop: 'fontSize',
+  key: 'fontSizes',
   transformValue: px,
-  scale: [12, 14, 16, 20, 24, 32, 48, 64, 72]
-});
+  scale: [12, 14, 16, 20, 24, 32, 48, 64, 72],
+})
 
 export const textColor = style({
-  prop: "color",
-  key: "colors"
-});
+  prop: 'color',
+  key: 'colors',
+})
 
 export const bgColor = style({
-  prop: "bg",
-  cssProperty: "backgroundColor",
-  key: "colors"
-});
+  prop: 'bg',
+  cssProperty: 'backgroundColor',
+  key: 'colors',
+})
 
 export const color = compose(
   textColor,
   bgColor
-);
+)
 
 // typography
 export const fontFamily = style({
-  prop: "fontFamily",
-  key: "fonts"
-});
+  prop: 'fontFamily',
+  key: 'fonts',
+})
 
 export const textAlign = style({
-  prop: "textAlign"
-});
+  prop: 'textAlign',
+})
 
 export const lineHeight = style({
-  prop: "lineHeight",
-  key: "lineHeights"
-});
+  prop: 'lineHeight',
+  key: 'lineHeights',
+})
 
 export const fontWeight = style({
-  prop: "fontWeight",
-  key: "fontWeights"
-});
+  prop: 'fontWeight',
+  key: 'fontWeights',
+})
 
 export const fontStyle = style({
-  prop: "fontStyle"
-});
+  prop: 'fontStyle',
+})
 
 export const letterSpacing = style({
-  prop: "letterSpacing",
-  key: "letterSpacings",
-  transformValue: px
-});
+  prop: 'letterSpacing',
+  key: 'letterSpacings',
+  transformValue: px,
+})
 
 // layout
 export const display = style({
-  prop: "display"
-});
+  prop: 'display',
+})
 
 export const maxWidth = style({
-  prop: "maxWidth",
-  key: "maxWidths",
-  transformValue: px
-});
+  prop: 'maxWidth',
+  key: 'maxWidths',
+  transformValue: px,
+})
 
 export const minWidth = style({
-  prop: "minWidth",
-  key: "minWidths",
-  transformValue: px
-});
+  prop: 'minWidth',
+  key: 'minWidths',
+  transformValue: px,
+})
 
 export const height = style({
-  prop: "height",
-  key: "heights",
-  transformValue: px
-});
+  prop: 'height',
+  key: 'heights',
+  transformValue: px,
+})
 
 export const maxHeight = style({
-  prop: "maxHeight",
-  key: "maxHeights",
-  transformValue: px
-});
+  prop: 'maxHeight',
+  key: 'maxHeights',
+  transformValue: px,
+})
 
 export const minHeight = style({
-  prop: "minHeight",
-  key: "minHeights",
-  transformValue: px
-});
+  prop: 'minHeight',
+  key: 'minHeights',
+  transformValue: px,
+})
 
 export const sizeWidth = style({
-  prop: "size",
-  cssProperty: "width",
-  transformValue: px
-});
+  prop: 'size',
+  cssProperty: 'width',
+  transformValue: px,
+})
 
 export const sizeHeight = style({
-  prop: "size",
-  cssProperty: "height",
-  transformValue: px
-});
+  prop: 'size',
+  cssProperty: 'height',
+  transformValue: px,
+})
 
 export const size = compose(
   sizeHeight,
   sizeWidth
-);
+)
 
 export const ratioPadding = style({
-  prop: "ratio",
-  cssProperty: "paddingBottom",
-  transformValue: n => n * 100 + "%"
-});
+  prop: 'ratio',
+  cssProperty: 'paddingBottom',
+  transformValue: n => n * 100 + '%',
+})
 
 export const ratio = props =>
   props.ratio
     ? {
         height: 0,
-        ...ratioPadding(props)
+        ...ratioPadding(props),
       }
-    : null;
+    : null
 ratio.propTypes = {
-  ...ratioPadding.propTypes
-};
+  ...ratioPadding.propTypes,
+}
 
 export const verticalAlign = style({
-  prop: "verticalAlign"
-});
+  prop: 'verticalAlign',
+})
 
 // flexbox
 export const alignItems = style({
-  prop: "alignItems"
-});
+  prop: 'alignItems',
+})
 
 export const alignContent = style({
-  prop: "alignContent"
-});
+  prop: 'alignContent',
+})
 
 export const justifyItems = style({
-  prop: "justifyItems"
-});
+  prop: 'justifyItems',
+})
 
 export const justifyContent = style({
-  prop: "justifyContent"
-});
+  prop: 'justifyContent',
+})
 
 export const flexWrap = style({
-  prop: "flexWrap"
-});
+  prop: 'flexWrap',
+})
 
 export const flexBasis = style({
-  prop: "flexBasis",
-  transformValue: getWidth
-});
+  prop: 'flexBasis',
+  transformValue: getWidth,
+})
 
 export const flexDirection = style({
-  prop: "flexDirection"
-});
+  prop: 'flexDirection',
+})
 
 export const flex = style({
-  prop: "flex"
-});
+  prop: 'flex',
+})
 
 export const justifySelf = style({
-  prop: "justifySelf"
-});
+  prop: 'justifySelf',
+})
 
 export const alignSelf = style({
-  prop: "alignSelf"
-});
+  prop: 'alignSelf',
+})
 
 export const order = style({
-  prop: "order"
-});
+  prop: 'order',
+})
 
 // grid
 export const gridGap = style({
-  prop: "gridGap",
+  prop: 'gridGap',
   transformValue: px,
-  key: "space"
-});
+  key: 'space',
+})
 
 export const gridColumnGap = style({
-  prop: "gridColumnGap",
+  prop: 'gridColumnGap',
   transformValue: px,
-  key: "space"
-});
+  key: 'space',
+})
 
 export const gridRowGap = style({
-  prop: "gridRowGap",
+  prop: 'gridRowGap',
   transformValue: px,
-  key: "space"
-});
+  key: 'space',
+})
 
 export const gridColumn = style({
-  prop: "gridColumn"
-});
+  prop: 'gridColumn',
+})
 
 export const gridRow = style({
-  prop: "gridRow"
-});
+  prop: 'gridRow',
+})
 
 export const gridAutoFlow = style({
-  prop: "gridAutoFlow"
-});
+  prop: 'gridAutoFlow',
+})
 
 export const gridAutoColumns = style({
-  prop: "gridAutoColumns"
-});
+  prop: 'gridAutoColumns',
+})
 
 export const gridAutoRows = style({
-  prop: "gridAutoRows"
-});
+  prop: 'gridAutoRows',
+})
 
 export const gridTemplateColumns = style({
-  prop: "gridTemplateColumns"
-});
+  prop: 'gridTemplateColumns',
+})
 
 export const gridTemplateRows = style({
-  prop: "gridTemplateRows"
-});
+  prop: 'gridTemplateRows',
+})
 
 export const gridTemplateAreas = style({
-  prop: "gridTemplateAreas"
-});
+  prop: 'gridTemplateAreas',
+})
 
 export const gridArea = style({
-  prop: "gridArea"
-});
+  prop: 'gridArea',
+})
 
 // borders
-const getBorder = n => (num(n) && n > 0 ? n + "px solid" : n);
+const getBorder = n => (num(n) && n > 0 ? n + 'px solid' : n)
 
 export const border = style({
-  prop: "border",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'border',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borderTop = style({
-  prop: "borderTop",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'borderTop',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borderRight = style({
-  prop: "borderRight",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'borderRight',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borderBottom = style({
-  prop: "borderBottom",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'borderBottom',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borderLeft = style({
-  prop: "borderLeft",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'borderLeft',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borders = compose(
   border,
@@ -524,95 +524,95 @@ export const borders = compose(
   borderRight,
   borderBottom,
   borderLeft
-);
+)
 
 export const borderColor = style({
-  prop: "borderColor",
-  key: "colors"
-});
+  prop: 'borderColor',
+  key: 'colors',
+})
 
 export const borderRadius = style({
-  prop: "borderRadius",
-  key: "radii",
-  transformValue: px
-});
+  prop: 'borderRadius',
+  key: 'radii',
+  transformValue: px,
+})
 
 export const boxShadow = style({
-  prop: "boxShadow",
-  key: "shadows"
-});
+  prop: 'boxShadow',
+  key: 'shadows',
+})
 
 export const opacity = style({
-  prop: "opacity"
-});
+  prop: 'opacity',
+})
 
 export const overflow = style({
-  prop: "overflow"
-});
+  prop: 'overflow',
+})
 
 // backgrounds
 export const background = style({
-  prop: "background"
-});
+  prop: 'background',
+})
 
 export const backgroundImage = style({
-  prop: "backgroundImage"
-});
+  prop: 'backgroundImage',
+})
 
 export const backgroundSize = style({
-  prop: "backgroundSize"
-});
+  prop: 'backgroundSize',
+})
 
 export const backgroundPosition = style({
-  prop: "backgroundPosition"
-});
+  prop: 'backgroundPosition',
+})
 
 export const backgroundRepeat = style({
-  prop: "backgroundRepeat"
-});
+  prop: 'backgroundRepeat',
+})
 
 // position
 export const position = style({
-  prop: "position"
-});
+  prop: 'position',
+})
 
 export const zIndex = style({
-  prop: "zIndex"
-});
+  prop: 'zIndex',
+})
 
 export const top = style({
-  prop: "top",
-  transformValue: px
-});
+  prop: 'top',
+  transformValue: px,
+})
 
 export const right = style({
-  prop: "right",
-  transformValue: px
-});
+  prop: 'right',
+  transformValue: px,
+})
 
 export const bottom = style({
-  prop: "bottom",
-  transformValue: px
-});
+  prop: 'bottom',
+  transformValue: px,
+})
 
 export const left = style({
-  prop: "left",
-  transformValue: px
-});
+  prop: 'left',
+  transformValue: px,
+})
 
 export const textStyle = variant({
-  prop: "textStyle",
-  key: "textStyles"
-});
+  prop: 'textStyle',
+  key: 'textStyles',
+})
 
 export const colorStyle = variant({
-  prop: "colors",
-  key: "colorStyles"
-});
+  prop: 'colors',
+  key: 'colorStyles',
+})
 
 export const buttonStyle = variant({
-  key: "buttons"
-});
+  key: 'buttons',
+})
 
 export const styles = {
   space,
@@ -687,27 +687,27 @@ export const styles = {
   left,
   textStyle,
   colorStyle,
-  buttonStyle
-};
+  buttonStyle,
+}
 
 // mixed
 const omit = (obj, blacklist) => {
-  const next = {};
+  const next = {}
   for (let key in obj) {
-    if (blacklist.indexOf(key) > -1) continue;
-    next[key] = obj[key];
+    if (blacklist.indexOf(key) > -1) continue
+    next[key] = obj[key]
   }
-  return next;
-};
+  return next
+}
 
 const funcs = Object.keys(styles)
   .map(key => styles[key])
-  .filter(fn => typeof fn === "function");
+  .filter(fn => typeof fn === 'function')
 
 const blacklist = funcs.reduce(
   (a, fn) => [...a, ...Object.keys(fn.propTypes || {})],
-  ["theme"]
-);
+  ['theme']
+)
 
 export const mixed = props =>
-  funcs.map(fn => fn(props)).reduce(merge, omit(props, blacklist));
+  funcs.map(fn => fn(props)).reduce(merge, omit(props, blacklist))

--- a/src/index.js
+++ b/src/index.js
@@ -52,18 +52,18 @@ export const compose = (...funcs) => {
 
 export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`
 
-const getStyles = (props, style, val) => {
-  if (!isObject(val)) {
-    return style(val)
+const getStyles = ({ props, style, value }) => {
+  if (!isObject(value)) {
+    return style(value)
   }
 
   // how to hoist this up??
   const breakpoints = get(props.theme, 'breakpoints') || defaultBreakpoints
   
-  if (isArray(val)) {
-    const styles = style(val[0]) || {}
-    for (let i = 1; i < val.length; i++) {
-      const rule = style(val[i])
+  if (isArray(value)) {
+    const styles = style(value[0]) || {}
+    for (let i = 1; i < value.length; i++) {
+      const rule = style(value[i])
       if (rule) {
         const media = createMediaQuery(breakpoints[i - 1])
         styles[media] = rule
@@ -73,12 +73,12 @@ const getStyles = (props, style, val) => {
   }
 
   let styles = {}
-  for (let breakpoint in val) {
+  for (let breakpoint in value) {
     const minWidth = breakpoints[breakpoint]
     if (!minWidth) {
-      styles = { ...styles, ...style(val[breakpoint]) }
+      styles = Object.assign({}, styles, style(value[breakpoint]))
     } else {
-      const rule = style(val[breakpoint])
+      const rule = style(value[breakpoint])
       const media = createMediaQuery(minWidth)
       styles[media] = rule
     }
@@ -98,8 +98,8 @@ export const style = ({
   const css = cssProperty || prop
   const transform  = transformValue || getter || noop
   const fn = props => {
-    const val = props[prop]
-    if (!is(val)) return null
+    const value = props[prop]
+    if (!is(value)) return null
 
     const scale = get(props.theme, key) || defaultScale
     const style = n => is(n) ? ({
@@ -108,7 +108,7 @@ export const style = ({
       )
     }) : null
 
-    return getStyles(props, style, val)
+    return getStyles({ props, style, value })
   }
 
   fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) }
@@ -202,7 +202,7 @@ export const space = props => {
 
   return keys
     .map(key => {
-      const val = props[key]
+      const value = props[key]
       const properties = getProperties(key)
 
       const style = n => is(n) ? properties.reduce((a, prop) => ({
@@ -210,7 +210,7 @@ export const space = props => {
         [prop]: getStyle(n)
       }), {}) : null
 
-      return getStyles(props, style, val)
+      return getStyles({ props, style, value })
     })
     .reduce(merge, {})
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export const defaultBreakpoints = [ 40, 52, 64, ].map(n => n + 'em')
 export const is = n => n !== undefined && n !== null
 export const num = n => typeof n === 'number' && !isNaN(n)
 export const px = n => num(n) ? n + 'px' : n
-export const isArray = n => Array.isArray(n)
+export const { isArray } = Array
 export const isObject = n => (typeof n === 'object' && n !== null)
 
 export const get = (obj, ...paths) => paths.join('.').split('.')

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ const getStyles = (props, style, val) => {
     return styles
   }
 
-  if (!isObject(breakpoints)) return null
+  if (isArray(breakpoints)) return null
 
   const styles = style(val.def) || {}
   for (let breakpoint in val) {

--- a/test/index.js
+++ b/test/index.js
@@ -340,10 +340,10 @@ test('space returns responsive paddings', t => {
   })
 })
 
-test('space can accept breakpoint map (object)', t => {
+test('space can accept a breakpoint map (object)', t => {
   const a = space({
-    theme: {breakpoints: {sm: '40em', md: '50em', lg: '60em'}},
-    p: {def: 1, md: 2}
+    theme: {breakpoints: {xs: 0, sm: '40em', md: '50em', lg: '60em'}},
+    p: {xs: 1, md: 2}
   })
 
   t.deepEqual(a, {
@@ -435,6 +435,19 @@ test('width returns responsive values', t => {
   t.deepEqual(a, {
     width: '100%',
     '@media screen and (min-width: 40em)': {width: '50%'},
+  })
+})
+
+test('width returns responsive values for object', t => {
+  const a = width({width: {0: 1, 2: 1/2}})
+
+  t.deepEqual(a, {
+    '@media screen and (min-width: 40em)': {
+      width: '100%'
+    },
+    '@media screen and (min-width: 64em)': {
+      width: '50%'
+    },
   })
 })
 
@@ -666,14 +679,14 @@ test('style allows array values', t => {
   })
 })
 
-test('style allows breakpoint map', t => {
+test('style allows a breakpoint map', t => {
   const direction = style({
     cssProperty: 'flex-direction',
     prop: 'direction'
   })
   const a = direction({
-    theme: { breakpoints: { sm: '40em', md: '50em', lg: '60em' } },
-    direction: { def: 'column', sm: 'row', lg: 'column' }
+    theme: { breakpoints: { default: null, sm: '40em', md: '50em', lg: '60em' } },
+    direction: { default: 'column', sm: 'row', lg: 'column' }
   })
   t.deepEqual(a, {
     'flex-direction': 'column',
@@ -686,7 +699,7 @@ test('style allows breakpoint map', t => {
   })
 })
 
-test('style allows breakpoint map without a default', t => {
+test('style allows a breakpoint map without a default', t => {
   const direction = style({
     cssProperty: 'flex-direction',
     prop: 'direction'

--- a/test/index.js
+++ b/test/index.js
@@ -340,6 +340,20 @@ test('space returns responsive paddings', t => {
   })
 })
 
+test('space can accept breakpoint map (object)', t => {
+  const a = space({
+    theme: {breakpoints: {sm: '40em', md: '50em', lg: '60em'}},
+    p: {def: 1, md: 2}
+  })
+
+  t.deepEqual(a, {
+    padding: '4px',
+    '@media screen and (min-width: 50em)': {
+      padding: '8px',
+    },
+  })
+})
+
 test('space returns responsive directional paddings', t => {
   const a = space({pt: [0, 1], pb: [2, 3]})
   t.deepEqual(a, {
@@ -648,6 +662,42 @@ test('style allows array values', t => {
     'flex-direction': 'column',
     '@media screen and (min-width: 52em)': {
       'flex-direction': 'row',
+    }
+  })
+})
+
+test('style allows breakpoint map', t => {
+  const direction = style({
+    cssProperty: 'flex-direction',
+    prop: 'direction'
+  })
+  const a = direction({
+    theme: { breakpoints: { sm: '40em', md: '50em', lg: '60em' } },
+    direction: { def: 'column', sm: 'row', lg: 'column' }
+  })
+  t.deepEqual(a, {
+    'flex-direction': 'column',
+    '@media screen and (min-width: 40em)': {
+      'flex-direction': 'row',
+    },
+    '@media screen and (min-width: 60em)': {
+      'flex-direction': 'column',
+    }
+  })
+})
+
+test('style allows breakpoint map without a default', t => {
+  const direction = style({
+    cssProperty: 'flex-direction',
+    prop: 'direction'
+  })
+  const a = direction({
+    theme: { breakpoints: { sm: '40em', md: '50em' } },
+    direction: { md: 'column' }
+  })
+  t.deepEqual(a, {
+    '@media screen and (min-width: 50em)': {
+      'flex-direction': 'column',
     }
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -344,8 +344,8 @@ test('space returns responsive paddings', t => {
 
 test('space can accept a breakpoint map (object)', t => {
   const a = space({
-    theme: {breakpoints: {xs: 0, sm: '40em', md: '50em', lg: '60em'}},
-    p: {xs: 1, md: 2}
+    theme: { breakpoints: { xs: 0, sm: '40em', md: '50em', lg: '60em' } },
+    p: { xs: 1, md: 2 },
   })
 
   t.deepEqual(a, {
@@ -406,16 +406,16 @@ test('space handles null values in arrays', t => {
 
 test('space handles undefined values in arrays', t => {
   const a = space({
-    m: [ 0,, 2 ],
+    m: [0, , 2],
     theme: {
-      space: [ 0, 4, 8, 16 ]
-    }
+      space: [0, 4, 8, 16],
+    },
   })
   t.deepEqual(a, {
     margin: '0px',
     '@media screen and (min-width: 52em)': {
-      margin: '8px'
-    }
+      margin: '8px',
+    },
   })
 })
 
@@ -456,14 +456,14 @@ test('width returns responsive values', t => {
 })
 
 test('width returns responsive values for object', t => {
-  const a = width({width: {0: 1, 2: 1/2}})
+  const a = width({ width: { 0: 1, 2: 1 / 2 } })
 
   t.deepEqual(a, {
     '@media screen and (min-width: 40em)': {
-      width: '100%'
+      width: '100%',
     },
     '@media screen and (min-width: 64em)': {
-      width: '50%'
+      width: '50%',
     },
   })
 })
@@ -695,25 +695,27 @@ test('style allows array values', t => {
 test('style allows array values with undefined', t => {
   const direction = style({
     cssProperty: 'flex-direction',
-    prop: 'direction'
+    prop: 'direction',
   })
-  const a = direction({ direction: [ 'column',, 'row' ] })
+  const a = direction({ direction: ['column', , 'row'] })
   t.deepEqual(a, {
     'flex-direction': 'column',
     '@media screen and (min-width: 52em)': {
       'flex-direction': 'row',
-    }
+    },
   })
 })
 
 test('style allows a breakpoint map', t => {
   const direction = style({
     cssProperty: 'flex-direction',
-    prop: 'direction'
+    prop: 'direction',
   })
   const a = direction({
-    theme: { breakpoints: { default: null, sm: '40em', md: '50em', lg: '60em' } },
-    direction: { default: 'column', sm: 'row', lg: 'column' }
+    theme: {
+      breakpoints: { default: null, sm: '40em', md: '50em', lg: '60em' },
+    },
+    direction: { default: 'column', sm: 'row', lg: 'column' },
   })
   t.deepEqual(a, {
     'flex-direction': 'column',
@@ -722,23 +724,23 @@ test('style allows a breakpoint map', t => {
     },
     '@media screen and (min-width: 60em)': {
       'flex-direction': 'column',
-    }
+    },
   })
 })
 
 test('style allows a breakpoint map without a default', t => {
   const direction = style({
     cssProperty: 'flex-direction',
-    prop: 'direction'
+    prop: 'direction',
   })
   const a = direction({
     theme: { breakpoints: { sm: '40em', md: '50em' } },
-    direction: { md: 'column' }
+    direction: { md: 'column' },
   })
   t.deepEqual(a, {
     '@media screen and (min-width: 50em)': {
       'flex-direction': 'column',
-    }
+    },
   })
 })
 
@@ -1265,11 +1267,11 @@ test('responsive props can have falsey values', t => {
 })
 
 test('responsive props can have undefined values', t => {
-  const dec = space({m: [, 1]})
+  const dec = space({ m: [, 1] })
   t.deepEqual(dec, {
     '@media screen and (min-width: 40em)': {
-      margin: '4px'
-    }
+      margin: '4px',
+    },
   })
 })
 


### PR DESCRIPTION
Hi,

I like the terseness of current responsive array syntax but in some situations I think it would be nice to provide breakpoint maps as well as arrays. For example, where you have a lot of breakpoints to avoid so many `null` values, or where you may need to insert new breakpoints.

Example:

```jsx
<Box p={[1, null, 2, null, null, 3]}>
```

Becomes:

```jsx
<Box p={{ def: 1, sm: 2, xl: 3 }}>
```

Where `theme.breakpoints` is no longer an array but something like `{ def: 0, xs: '32em', sm: '40em', md: '56em', lg: '64em', xl: '80em' }`.

That's what this PR introduces, in what is (at least according to the tests) a non-breaking way, as well as moving some duplicated code to shared function `getStyles`.

I figure you may well have considered and dismissed it from an API design perspective. But I'm going to use it in the fork, so just thought I'd share back 😄 . 

I can remove the breakpoint map changes if you are interested in some of the lightweight refactoring / removal of duplication between the `style` and `space` functions.