### PR TITLE
feat(space): allow nested objects in space

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9735,6 +9735,12 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+      "dev": true
+    },
     "pretty-ms": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "prepare": "npm run clean && npm run build:cjs && npm run build:esm",
+    "prettier": "prettier \"{src,test}/**/*.js\"",
     "clean": "rm -rf dist && mkdir dist",
     "build:cjs": "cross-env NODE_ENV=cjs babel src -o dist/index.cjs.js",
     "build:esm": "cross-env NODE_ENV=esm babel src -o dist/index.esm.js",
@@ -41,6 +42,7 @@
     "is-ci": "^1.1.0",
     "mdx-go": "^2.0.0-29",
     "nyc": "^12.0.2",
+    "prettier": "^1.15.3",
     "react": "^16.4.0",
     "react-live": "^1.11.0",
     "react-test-renderer": "^16.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,32 @@
-import PropTypes from "prop-types";
+import PropTypes from 'prop-types'
 
 // utils
-const noop = n => n;
+const noop = n => n
 
 export const propTypes = {
   numberOrString: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   responsive: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
-    PropTypes.array
-  ])
-};
+    PropTypes.array,
+  ]),
+}
 
-export const defaultBreakpoints = [40, 52, 64].map(n => n + "em");
-export const is = n => n !== undefined && n !== null;
-export const num = n => typeof n === "number" && !isNaN(n);
-export const px = n => (num(n) ? n + "px" : n);
+export const defaultBreakpoints = [40, 52, 64].map(n => n + 'em')
+export const is = n => n !== undefined && n !== null
+export const num = n => typeof n === 'number' && !isNaN(n)
+export const px = n => (num(n) ? n + 'px' : n)
 
 export const get = (obj, ...paths) =>
   paths
-    .join(".")
-    .split(".")
-    .reduce((a, b) => (a && a[b] ? a[b] : null), obj);
+    .join('.')
+    .split('.')
+    .reduce((a, b) => (a && a[b] ? a[b] : null), obj)
 
 export const themeGet = (paths, fallback) => props =>
-  get(props.theme, paths) || fallback;
+  get(props.theme, paths) || fallback
 
-export const cloneFunc = fn => (...args) => fn(...args);
+export const cloneFunc = fn => (...args) => fn(...args)
 
 export const merge = (a, b) =>
   Object.assign(
@@ -37,26 +37,26 @@ export const merge = (a, b) =>
       (obj, key) =>
         Object.assign(obj, {
           [key]:
-            a[key] !== null && typeof a[key] === "object"
+            a[key] !== null && typeof a[key] === 'object'
               ? merge(a[key], b[key])
-              : b[key]
+              : b[key],
         }),
       {}
     )
-  );
+  )
 
 export const compose = (...funcs) => {
   const fn = props =>
     funcs
       .map(fn => fn(props))
       .filter(Boolean)
-      .reduce(merge, {});
+      .reduce(merge, {})
 
-  fn.propTypes = funcs.map(fn => fn.propTypes).reduce(merge, {});
-  return fn;
-};
+  fn.propTypes = funcs.map(fn => fn.propTypes).reduce(merge, {})
+  return fn
+}
 
-export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`;
+export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`
 
 export const style = ({
   prop,
@@ -64,71 +64,71 @@ export const style = ({
   key,
   getter,
   transformValue,
-  scale: defaultScale = {}
+  scale: defaultScale = {},
 }) => {
-  const css = cssProperty || prop;
-  const transform = transformValue || getter || noop;
+  const css = cssProperty || prop
+  const transform = transformValue || getter || noop
   const fn = props => {
-    const val = props[prop];
-    if (!is(val)) return null;
+    const val = props[prop]
+    if (!is(val)) return null
 
-    const scale = get(props.theme, key) || defaultScale;
+    const scale = get(props.theme, key) || defaultScale
     const style = n =>
       is(n)
         ? {
-            [css]: transform(get(scale, n) || n)
+            [css]: transform(get(scale, n) || n),
           }
-        : null;
+        : null
 
     if (!Array.isArray(val)) {
-      return style(val);
+      return style(val)
     }
 
     // how to hoist this up??
     const breakpoints = [
       null,
-      ...(get(props.theme, "breakpoints") || defaultBreakpoints).map(
+      ...(get(props.theme, 'breakpoints') || defaultBreakpoints).map(
         createMediaQuery
-      )
-    ];
+      ),
+    ]
 
-    let styles = {};
+    let styles = {}
 
     for (let i = 0; i < val.length; i++) {
-      const media = breakpoints[i];
+      const media = breakpoints[i]
       if (!media) {
-        styles = style(val[i]) || {};
-        continue;
+        styles = style(val[i]) || {}
+        continue
       }
-      const rule = style(val[i]);
-      if (!rule) continue;
-      styles[media] = rule;
+      const rule = style(val[i])
+      if (!rule) continue
+      styles[media] = rule
     }
 
-    return styles;
-  };
+    return styles
+  }
 
-  fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) };
+  fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) }
 
   fn.propTypes[prop].meta = {
     prop,
     themeKey: key,
-    styleType: "responsive"
-  };
+    styleType: 'responsive',
+  }
 
-  return fn;
-};
+  return fn
+}
 
-export const getWidth = n => (!num(n) || n > 1 ? px(n) : n * 100 + "%");
+export const getWidth = n => (!num(n) || n > 1 ? px(n) : n * 100 + '%')
 
 // variant
-export const variant = ({ key, prop = "variant" }) => {
-  const fn = props => get(props.theme, key, props[prop]) || null;
+export const variant = ({ key, prop = 'variant' }) => {
+  const fn = props => get(props.theme, key, props[prop]) || null
   fn.propTypes = {
-    [prop]: propTypes.numberOrString
-  };
-  return fn;
-};
+    [prop]: propTypes.numberOrString,
+  }
+  return fn
+}
 
 export const util = {
   propTypes,
@@ -142,100 +142,100 @@ export const util = {
   merge,
   compose,
   createMediaQuery,
-  style
-};
+  style,
+}
 
 // space
-const isNegative = n => n < 0;
-const REG = /^[mp][trblxy]?$/;
+const isNegative = n => n < 0
+const REG = /^[mp][trblxy]?$/
 const properties = {
-  m: "margin",
-  p: "padding"
-};
+  m: 'margin',
+  p: 'padding',
+}
 const directions = {
-  t: "Top",
-  r: "Right",
-  b: "Bottom",
-  l: "Left",
-  x: ["Left", "Right"],
-  y: ["Top", "Bottom"]
-};
+  t: 'Top',
+  r: 'Right',
+  b: 'Bottom',
+  l: 'Left',
+  x: ['Left', 'Right'],
+  y: ['Top', 'Bottom'],
+}
 
 const getProperties = key => {
-  const [a, b] = key.split("");
-  const property = properties[a];
-  const direction = directions[b] || "";
+  const [a, b] = key.split('')
+  const property = properties[a]
+  const direction = directions[b] || ''
   return Array.isArray(direction)
     ? direction.map(dir => property + dir)
-    : [property + direction];
-};
+    : [property + direction]
+}
 
 const getValue = scale => n => {
   if (!num(n)) {
-    return px(get(scale, n) || n);
+    return px(get(scale, n) || n)
   }
-  const abs = Math.abs(n);
-  const neg = isNegative(n);
-  const value = scale[abs] || abs;
+  const abs = Math.abs(n)
+  const neg = isNegative(n)
+  const value = scale[abs] || abs
   if (!num(value)) {
-    return neg ? "-" + value : value;
+    return neg ? '-' + value : value
   }
-  return px(value * (neg ? -1 : 1));
-};
+  return px(value * (neg ? -1 : 1))
+}
 
-const defaultScale = [0, 4, 8, 16, 32, 64, 128, 256, 512];
+const defaultScale = [0, 4, 8, 16, 32, 64, 128, 256, 512]
 
 export const space = props => {
   const keys = Object.keys(props)
     .filter(key => REG.test(key))
-    .sort();
-  const scale = get(props.theme, "space") || defaultScale;
-  const getStyle = getValue(scale);
+    .sort()
+  const scale = get(props.theme, 'space') || defaultScale
+  const getStyle = getValue(scale)
 
   return keys
     .map(key => {
-      const value = props[key];
-      const properties = getProperties(key);
+      const value = props[key]
+      const properties = getProperties(key)
 
       const style = n =>
         is(n)
           ? properties.reduce(
               (a, prop) => ({
                 ...a,
-                [prop]: getStyle(n)
+                [prop]: getStyle(n),
               }),
               {}
             )
-          : null;
+          : null
 
       if (!Array.isArray(value)) {
-        return style(value);
+        return style(value)
       }
 
       const breakpoints = [
         null,
-        ...(get(props.theme, "breakpoints") || defaultBreakpoints).map(
+        ...(get(props.theme, 'breakpoints') || defaultBreakpoints).map(
           createMediaQuery
-        )
-      ];
+        ),
+      ]
 
-      let styles = {};
+      let styles = {}
 
       for (let i = 0; i < value.length; i++) {
-        const media = breakpoints[i];
+        const media = breakpoints[i]
         if (!media) {
-          styles = style(value[i]) || {};
-          continue;
+          styles = style(value[i]) || {}
+          continue
         }
-        const rule = style(value[i]);
-        if (!rule) continue;
-        styles[media] = rule;
+        const rule = style(value[i])
+        if (!rule) continue
+        styles[media] = rule
       }
 
-      return styles;
+      return styles
     })
-    .reduce(merge, {});
-};
+    .reduce(merge, {})
+}
 
 space.propTypes = {
   m: cloneFunc(propTypes.responsive),
@@ -251,284 +251,284 @@ space.propTypes = {
   pb: cloneFunc(propTypes.responsive),
   pl: cloneFunc(propTypes.responsive),
   px: cloneFunc(propTypes.responsive),
-  py: cloneFunc(propTypes.responsive)
-};
+  py: cloneFunc(propTypes.responsive),
+}
 
 const meta = prop => ({
   prop,
-  themeKey: "space",
-  styleType: "responsive"
-});
+  themeKey: 'space',
+  styleType: 'responsive',
+})
 
 Object.keys(space.propTypes).forEach(prop => {
-  space.propTypes[prop].meta = meta(prop);
-});
+  space.propTypes[prop].meta = meta(prop)
+})
 
 // styles
 export const width = style({
-  prop: "width",
-  transformValue: getWidth
-});
+  prop: 'width',
+  transformValue: getWidth,
+})
 
 export const fontSize = style({
-  prop: "fontSize",
-  key: "fontSizes",
+  prop: 'fontSize',
+  key: 'fontSizes',
   transformValue: px,
-  scale: [12, 14, 16, 20, 24, 32, 48, 64, 72]
-});
+  scale: [12, 14, 16, 20, 24, 32, 48, 64, 72],
+})
 
 export const textColor = style({
-  prop: "color",
-  key: "colors"
-});
+  prop: 'color',
+  key: 'colors',
+})
 
 export const bgColor = style({
-  prop: "bg",
-  cssProperty: "backgroundColor",
-  key: "colors"
-});
+  prop: 'bg',
+  cssProperty: 'backgroundColor',
+  key: 'colors',
+})
 
 export const color = compose(
   textColor,
   bgColor
-);
+)
 
 // typography
 export const fontFamily = style({
-  prop: "fontFamily",
-  key: "fonts"
-});
+  prop: 'fontFamily',
+  key: 'fonts',
+})
 
 export const textAlign = style({
-  prop: "textAlign"
-});
+  prop: 'textAlign',
+})
 
 export const lineHeight = style({
-  prop: "lineHeight",
-  key: "lineHeights"
-});
+  prop: 'lineHeight',
+  key: 'lineHeights',
+})
 
 export const fontWeight = style({
-  prop: "fontWeight",
-  key: "fontWeights"
-});
+  prop: 'fontWeight',
+  key: 'fontWeights',
+})
 
 export const fontStyle = style({
-  prop: "fontStyle"
-});
+  prop: 'fontStyle',
+})
 
 export const letterSpacing = style({
-  prop: "letterSpacing",
-  key: "letterSpacings",
-  transformValue: px
-});
+  prop: 'letterSpacing',
+  key: 'letterSpacings',
+  transformValue: px,
+})
 
 // layout
 export const display = style({
-  prop: "display"
-});
+  prop: 'display',
+})
 
 export const maxWidth = style({
-  prop: "maxWidth",
-  key: "maxWidths",
-  transformValue: px
-});
+  prop: 'maxWidth',
+  key: 'maxWidths',
+  transformValue: px,
+})
 
 export const minWidth = style({
-  prop: "minWidth",
-  key: "minWidths",
-  transformValue: px
-});
+  prop: 'minWidth',
+  key: 'minWidths',
+  transformValue: px,
+})
 
 export const height = style({
-  prop: "height",
-  key: "heights",
-  transformValue: px
-});
+  prop: 'height',
+  key: 'heights',
+  transformValue: px,
+})
 
 export const maxHeight = style({
-  prop: "maxHeight",
-  key: "maxHeights",
-  transformValue: px
-});
+  prop: 'maxHeight',
+  key: 'maxHeights',
+  transformValue: px,
+})
 
 export const minHeight = style({
-  prop: "minHeight",
-  key: "minHeights",
-  transformValue: px
-});
+  prop: 'minHeight',
+  key: 'minHeights',
+  transformValue: px,
+})
 
 export const sizeWidth = style({
-  prop: "size",
-  cssProperty: "width",
-  transformValue: px
-});
+  prop: 'size',
+  cssProperty: 'width',
+  transformValue: px,
+})
 
 export const sizeHeight = style({
-  prop: "size",
-  cssProperty: "height",
-  transformValue: px
-});
+  prop: 'size',
+  cssProperty: 'height',
+  transformValue: px,
+})
 
 export const size = compose(
   sizeHeight,
   sizeWidth
-);
+)
 
 export const ratioPadding = style({
-  prop: "ratio",
-  cssProperty: "paddingBottom",
-  transformValue: n => n * 100 + "%"
-});
+  prop: 'ratio',
+  cssProperty: 'paddingBottom',
+  transformValue: n => n * 100 + '%',
+})
 
 export const ratio = props =>
   props.ratio
     ? {
         height: 0,
-        ...ratioPadding(props)
+        ...ratioPadding(props),
       }
-    : null;
+    : null
 ratio.propTypes = {
-  ...ratioPadding.propTypes
-};
+  ...ratioPadding.propTypes,
+}
 
 export const verticalAlign = style({
-  prop: "verticalAlign"
-});
+  prop: 'verticalAlign',
+})
 
 // flexbox
 export const alignItems = style({
-  prop: "alignItems"
-});
+  prop: 'alignItems',
+})
 
 export const alignContent = style({
-  prop: "alignContent"
-});
+  prop: 'alignContent',
+})
 
 export const justifyItems = style({
-  prop: "justifyItems"
-});
+  prop: 'justifyItems',
+})
 
 export const justifyContent = style({
-  prop: "justifyContent"
-});
+  prop: 'justifyContent',
+})
 
 export const flexWrap = style({
-  prop: "flexWrap"
-});
+  prop: 'flexWrap',
+})
 
 export const flexBasis = style({
-  prop: "flexBasis",
-  transformValue: getWidth
-});
+  prop: 'flexBasis',
+  transformValue: getWidth,
+})
 
 export const flexDirection = style({
-  prop: "flexDirection"
-});
+  prop: 'flexDirection',
+})
 
 export const flex = style({
-  prop: "flex"
-});
+  prop: 'flex',
+})
 
 export const justifySelf = style({
-  prop: "justifySelf"
-});
+  prop: 'justifySelf',
+})
 
 export const alignSelf = style({
-  prop: "alignSelf"
-});
+  prop: 'alignSelf',
+})
 
 export const order = style({
-  prop: "order"
-});
+  prop: 'order',
+})
 
 // grid
 export const gridGap = style({
-  prop: "gridGap",
+  prop: 'gridGap',
   transformValue: px,
-  key: "space"
-});
+  key: 'space',
+})
 
 export const gridColumnGap = style({
-  prop: "gridColumnGap",
+  prop: 'gridColumnGap',
   transformValue: px,
-  key: "space"
-});
+  key: 'space',
+})
 
 export const gridRowGap = style({
-  prop: "gridRowGap",
+  prop: 'gridRowGap',
   transformValue: px,
-  key: "space"
-});
+  key: 'space',
+})
 
 export const gridColumn = style({
-  prop: "gridColumn"
-});
+  prop: 'gridColumn',
+})
 
 export const gridRow = style({
-  prop: "gridRow"
-});
+  prop: 'gridRow',
+})
 
 export const gridAutoFlow = style({
-  prop: "gridAutoFlow"
-});
+  prop: 'gridAutoFlow',
+})
 
 export const gridAutoColumns = style({
-  prop: "gridAutoColumns"
-});
+  prop: 'gridAutoColumns',
+})
 
 export const gridAutoRows = style({
-  prop: "gridAutoRows"
-});
+  prop: 'gridAutoRows',
+})
 
 export const gridTemplateColumns = style({
-  prop: "gridTemplateColumns"
-});
+  prop: 'gridTemplateColumns',
+})
 
 export const gridTemplateRows = style({
-  prop: "gridTemplateRows"
-});
+  prop: 'gridTemplateRows',
+})
 
 export const gridTemplateAreas = style({
-  prop: "gridTemplateAreas"
-});
+  prop: 'gridTemplateAreas',
+})
 
 export const gridArea = style({
-  prop: "gridArea"
-});
+  prop: 'gridArea',
+})
 
 // borders
-const getBorder = n => (num(n) && n > 0 ? n + "px solid" : n);
+const getBorder = n => (num(n) && n > 0 ? n + 'px solid' : n)
 
 export const border = style({
-  prop: "border",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'border',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borderTop = style({
-  prop: "borderTop",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'borderTop',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borderRight = style({
-  prop: "borderRight",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'borderRight',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borderBottom = style({
-  prop: "borderBottom",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'borderBottom',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borderLeft = style({
-  prop: "borderLeft",
-  key: "borders",
-  transformValue: getBorder
-});
+  prop: 'borderLeft',
+  key: 'borders',
+  transformValue: getBorder,
+})
 
 export const borders = compose(
   border,
@@ -536,95 +536,95 @@ export const borders = compose(
   borderRight,
   borderBottom,
   borderLeft
-);
+)
 
 export const borderColor = style({
-  prop: "borderColor",
-  key: "colors"
-});
+  prop: 'borderColor',
+  key: 'colors',
+})
 
 export const borderRadius = style({
-  prop: "borderRadius",
-  key: "radii",
-  transformValue: px
-});
+  prop: 'borderRadius',
+  key: 'radii',
+  transformValue: px,
+})
 
 export const boxShadow = style({
-  prop: "boxShadow",
-  key: "shadows"
-});
+  prop: 'boxShadow',
+  key: 'shadows',
+})
 
 export const opacity = style({
-  prop: "opacity"
-});
+  prop: 'opacity',
+})
 
 export const overflow = style({
-  prop: "overflow"
-});
+  prop: 'overflow',
+})
 
 // backgrounds
 export const background = style({
-  prop: "background"
-});
+  prop: 'background',
+})
 
 export const backgroundImage = style({
-  prop: "backgroundImage"
-});
+  prop: 'backgroundImage',
+})
 
 export const backgroundSize = style({
-  prop: "backgroundSize"
-});
+  prop: 'backgroundSize',
+})
 
 export const backgroundPosition = style({
-  prop: "backgroundPosition"
-});
+  prop: 'backgroundPosition',
+})
 
 export const backgroundRepeat = style({
-  prop: "backgroundRepeat"
-});
+  prop: 'backgroundRepeat',
+})
 
 // position
 export const position = style({
-  prop: "position"
-});
+  prop: 'position',
+})
 
 export const zIndex = style({
-  prop: "zIndex"
-});
+  prop: 'zIndex',
+})
 
 export const top = style({
-  prop: "top",
-  transformValue: px
-});
+  prop: 'top',
+  transformValue: px,
+})
 
 export const right = style({
-  prop: "right",
-  transformValue: px
-});
+  prop: 'right',
+  transformValue: px,
+})
 
 export const bottom = style({
-  prop: "bottom",
-  transformValue: px
-});
+  prop: 'bottom',
+  transformValue: px,
+})
 
 export const left = style({
-  prop: "left",
-  transformValue: px
-});
+  prop: 'left',
+  transformValue: px,
+})
 
 export const textStyle = variant({
-  prop: "textStyle",
-  key: "textStyles"
-});
+  prop: 'textStyle',
+  key: 'textStyles',
+})
 
 export const colorStyle = variant({
-  prop: "colors",
-  key: "colorStyles"
-});
+  prop: 'colors',
+  key: 'colorStyles',
+})
 
 export const buttonStyle = variant({
-  key: "buttons"
-});
+  key: 'buttons',
+})
 
 export const styles = {
   space,
@@ -699,27 +699,27 @@ export const styles = {
   left,
   textStyle,
   colorStyle,
-  buttonStyle
-};
+  buttonStyle,
+}
 
 // mixed
 const omit = (obj, blacklist) => {
-  const next = {};
+  const next = {}
   for (let key in obj) {
-    if (blacklist.indexOf(key) > -1) continue;
-    next[key] = obj[key];
+    if (blacklist.indexOf(key) > -1) continue
+    next[key] = obj[key]
   }
-  return next;
-};
+  return next
+}
 
 const funcs = Object.keys(styles)
   .map(key => styles[key])
-  .filter(fn => typeof fn === "function");
+  .filter(fn => typeof fn === 'function')
 
 const blacklist = funcs.reduce(
   (a, fn) => [...a, ...Object.keys(fn.propTypes || {})],
-  ["theme"]
-);
+  ['theme']
+)
 
 export const mixed = props =>
-  funcs.map(fn => fn(props)).reduce(merge, omit(props, blacklist));
+  funcs.map(fn => fn(props)).reduce(merge, omit(props, blacklist))

--- a/src/index.js
+++ b/src/index.js
@@ -1,54 +1,62 @@
-import PropTypes from 'prop-types'
+import PropTypes from "prop-types";
 
 // utils
-const noop = n => n
+const noop = n => n;
 
 export const propTypes = {
-  numberOrString: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]),
+  numberOrString: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   responsive: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
-    PropTypes.array,
-  ]),
-}
+    PropTypes.array
+  ])
+};
 
-export const defaultBreakpoints = [ 40, 52, 64, ].map(n => n + 'em')
-export const is = n => n !== undefined && n !== null
-export const num = n => typeof n === 'number' && !isNaN(n)
-export const px = n => num(n) ? n + 'px' : n
+export const defaultBreakpoints = [40, 52, 64].map(n => n + "em");
+export const is = n => n !== undefined && n !== null;
+export const num = n => typeof n === "number" && !isNaN(n);
+export const px = n => (num(n) ? n + "px" : n);
 
-export const get = (obj, ...paths) => paths.join('.').split('.')
-  .reduce((a, b) => (a && a[b]) ? a[b] : null, obj)
+export const get = (obj, ...paths) =>
+  paths
+    .join(".")
+    .split(".")
+    .reduce((a, b) => (a && a[b] ? a[b] : null), obj);
 
-export const themeGet = (paths, fallback) => props => get(props.theme, paths) || fallback
+export const themeGet = (paths, fallback) => props =>
+  get(props.theme, paths) || fallback;
 
-export const cloneFunc = fn => (...args) => fn(...args)
+export const cloneFunc = fn => (...args) => fn(...args);
 
-export const merge = (a, b) => Object.assign({}, a, b, Object
-  .keys(b || {}).reduce((obj, key) =>
-    Object.assign(obj, {
-      [key]: a[key] !== null && typeof a[key] === 'object'
-      ? merge(a[key], b[key])
-      : b[key]
-    }),
-    {}))
+export const merge = (a, b) =>
+  Object.assign(
+    {},
+    a,
+    b,
+    Object.keys(b || {}).reduce(
+      (obj, key) =>
+        Object.assign(obj, {
+          [key]:
+            a[key] !== null && typeof a[key] === "object"
+              ? merge(a[key], b[key])
+              : b[key]
+        }),
+      {}
+    )
+  );
 
 export const compose = (...funcs) => {
-  const fn = props => funcs
-    .map(fn => fn(props))
-    .filter(Boolean)
-    .reduce(merge, {})
+  const fn = props =>
+    funcs
+      .map(fn => fn(props))
+      .filter(Boolean)
+      .reduce(merge, {});
 
-  fn.propTypes = funcs
-    .map(fn => fn.propTypes)
-    .reduce(merge, {})
-  return fn
-}
+  fn.propTypes = funcs.map(fn => fn.propTypes).reduce(merge, {});
+  return fn;
+};
 
-export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`
+export const createMediaQuery = n => `@media screen and (min-width: ${px(n)})`;
 
 export const style = ({
   prop,
@@ -58,70 +66,69 @@ export const style = ({
   transformValue,
   scale: defaultScale = {}
 }) => {
-  const css = cssProperty || prop
-  const transform  = transformValue || getter || noop
+  const css = cssProperty || prop;
+  const transform = transformValue || getter || noop;
   const fn = props => {
-    const val = props[prop]
-    if (!is(val)) return null
+    const val = props[prop];
+    if (!is(val)) return null;
 
-    const scale = get(props.theme, key) || defaultScale
-    const style = n => is(n) ? ({
-      [css]: transform(
-        get(scale, n) || n
-      )
-    }) : null
+    const scale = get(props.theme, key) || defaultScale;
+    const style = n =>
+      is(n)
+        ? {
+            [css]: transform(get(scale, n) || n)
+          }
+        : null;
 
     if (!Array.isArray(val)) {
-      return style(val)
+      return style(val);
     }
 
     // how to hoist this up??
     const breakpoints = [
       null,
-      ...(get(props.theme, 'breakpoints') || defaultBreakpoints)
-        .map(createMediaQuery)
-    ]
+      ...(get(props.theme, "breakpoints") || defaultBreakpoints).map(
+        createMediaQuery
+      )
+    ];
 
-    let styles = {}
+    let styles = {};
 
     for (let i = 0; i < val.length; i++) {
-      const media = breakpoints[i]
+      const media = breakpoints[i];
       if (!media) {
-        styles = style(val[i]) || {}
-        continue
+        styles = style(val[i]) || {};
+        continue;
       }
-      const rule = style(val[i])
-      if (!rule) continue
-      styles[media] = rule
+      const rule = style(val[i]);
+      if (!rule) continue;
+      styles[media] = rule;
     }
 
-    return styles
-  }
+    return styles;
+  };
 
-  fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) }
+  fn.propTypes = { [prop]: cloneFunc(propTypes.responsive) };
 
   fn.propTypes[prop].meta = {
     prop,
     themeKey: key,
-    styleType: 'responsive'
-  }
+    styleType: "responsive"
+  };
 
-  return fn
-}
+  return fn;
+};
 
-export const getWidth = n => !num(n) || n > 1 ? px(n) : (n * 100) + '%'
+export const getWidth = n => (!num(n) || n > 1 ? px(n) : n * 100 + "%");
 
 // variant
-export const variant = ({
-  key,
-  prop = 'variant'
-}) => {
-  const fn = (props) => get(props.theme, key, props[prop]) || null
+export const variant = ({ key, prop = "variant" }) => {
+  const fn = props => get(props.theme, key, props[prop]) || null;
   fn.propTypes = {
     [prop]: propTypes.numberOrString
-  }
-  return fn
-}
+  };
+  return fn;
+};
 
 export const util = {
   propTypes,
@@ -135,396 +142,393 @@ export const util = {
   merge,
   compose,
   createMediaQuery,
-  style,
-}
+  style
+};
 
 // space
-const isNegative = n => n < 0
-const REG = /^[mp][trblxy]?$/
+const isNegative = n => n < 0;
+const REG = /^[mp][trblxy]?$/;
 const properties = {
-  m: 'margin',
-  p: 'padding'
-}
+  m: "margin",
+  p: "padding"
+};
 const directions = {
-  t: 'Top',
-  r: 'Right',
-  b: 'Bottom',
-  l: 'Left',
-  x: [ 'Left', 'Right' ],
-  y: [ 'Top', 'Bottom' ],
-}
+  t: "Top",
+  r: "Right",
+  b: "Bottom",
+  l: "Left",
+  x: ["Left", "Right"],
+  y: ["Top", "Bottom"]
+};
 
 const getProperties = key => {
-  const [ a, b ] = key.split('')
-  const property = properties[a]
-  const direction = directions[b] || ''
+  const [a, b] = key.split("");
+  const property = properties[a];
+  const direction = directions[b] || "";
   return Array.isArray(direction)
     ? direction.map(dir => property + dir)
-    : [ property + direction ]
-}
+    : [property + direction];
+};
 
 const getValue = scale => n => {
   if (!num(n)) {
-    return px(scale[n] || n)
+    return px(get(scale, n) || n);
   }
-  const abs = Math.abs(n)
-  const neg = isNegative(n)
-  const value = scale[abs] || abs
+  const abs = Math.abs(n);
+  const neg = isNegative(n);
+  const value = scale[abs] || abs;
   if (!num(value)) {
-    return neg ? '-' + value : value
+    return neg ? "-" + value : value;
   }
-  return px(value * (neg ? -1 : 1))
-}
+  return px(value * (neg ? -1 : 1));
+};
 
-const defaultScale = [
-  0, 4, 8, 16, 32, 64, 128, 256, 512
-]
+const defaultScale = [0, 4, 8, 16, 32, 64, 128, 256, 512];
 
 export const space = props => {
   const keys = Object.keys(props)
     .filter(key => REG.test(key))
-    .sort()
-  const scale = get(props.theme, 'space') || defaultScale
-  const getStyle = getValue(scale)
+    .sort();
+  const scale = get(props.theme, "space") || defaultScale;
+  const getStyle = getValue(scale);
 
   return keys
     .map(key => {
-      const value = props[key]
-      const properties = getProperties(key)
+      const value = props[key];
+      const properties = getProperties(key);
 
-      const style = n => is(n) ? properties.reduce((a, prop) => ({
-        ...a,
-        [prop]: getStyle(n)
-      }), {}) : null
+      const style = n =>
+        is(n)
+          ? properties.reduce(
+              (a, prop) => ({
+                ...a,
+                [prop]: getStyle(n)
+              }),
+              {}
+            )
+          : null;
 
       if (!Array.isArray(value)) {
-        return style(value)
+        return style(value);
       }
 
       const breakpoints = [
         null,
-        ...(get(props.theme, 'breakpoints') || defaultBreakpoints)
-          .map(createMediaQuery)
-      ]
+        ...(get(props.theme, "breakpoints") || defaultBreakpoints).map(
+          createMediaQuery
+        )
+      ];
 
-      let styles = {}
+      let styles = {};
 
       for (let i = 0; i < value.length; i++) {
-        const media = breakpoints[i]
+        const media = breakpoints[i];
         if (!media) {
-          styles = style(value[i]) || {}
-          continue
+          styles = style(value[i]) || {};
+          continue;
         }
-        const rule = style(value[i])
-        if (!rule) continue
-        styles[media] = rule
+        const rule = style(value[i]);
+        if (!rule) continue;
+        styles[media] = rule;
       }
 
-      return styles
+      return styles;
     })
-    .reduce(merge, {})
-}
+    .reduce(merge, {});
+};
 
 space.propTypes = {
-  m:  cloneFunc(propTypes.responsive),
+  m: cloneFunc(propTypes.responsive),
   mt: cloneFunc(propTypes.responsive),
   mr: cloneFunc(propTypes.responsive),
   mb: cloneFunc(propTypes.responsive),
   ml: cloneFunc(propTypes.responsive),
   mx: cloneFunc(propTypes.responsive),
   my: cloneFunc(propTypes.responsive),
-  p:  cloneFunc(propTypes.responsive),
+  p: cloneFunc(propTypes.responsive),
   pt: cloneFunc(propTypes.responsive),
   pr: cloneFunc(propTypes.responsive),
   pb: cloneFunc(propTypes.responsive),
   pl: cloneFunc(propTypes.responsive),
   px: cloneFunc(propTypes.responsive),
   py: cloneFunc(propTypes.responsive)
-}
+};
 
 const meta = prop => ({
   prop,
-  themeKey: 'space',
-  styleType: 'responsive'
-})
+  themeKey: "space",
+  styleType: "responsive"
+});
 
 Object.keys(space.propTypes).forEach(prop => {
-  space.propTypes[prop].meta = meta(prop)
-})
+  space.propTypes[prop].meta = meta(prop);
+});
 
 // styles
 export const width = style({
-  prop: 'width',
+  prop: "width",
   transformValue: getWidth
-})
+});
 
 export const fontSize = style({
-  prop: 'fontSize',
-  key: 'fontSizes',
+  prop: "fontSize",
+  key: "fontSizes",
   transformValue: px,
-  scale: [
-    12,
-    14,
-    16,
-    20,
-    24,
-    32,
-    48,
-    64,
-    72
-  ]
-})
+  scale: [12, 14, 16, 20, 24, 32, 48, 64, 72]
+});
 
 export const textColor = style({
-  prop: 'color',
-  key: 'colors',
-})
+  prop: "color",
+  key: "colors"
+});
 
 export const bgColor = style({
-  prop: 'bg',
-  cssProperty: 'backgroundColor',
-  key: 'colors'
-})
+  prop: "bg",
+  cssProperty: "backgroundColor",
+  key: "colors"
+});
 
 export const color = compose(
   textColor,
   bgColor
-)
+);
 
 // typography
 export const fontFamily = style({
-  prop: 'fontFamily',
-  key: 'fonts'
-})
+  prop: "fontFamily",
+  key: "fonts"
+});
 
 export const textAlign = style({
-  prop: 'textAlign'
-})
+  prop: "textAlign"
+});
 
 export const lineHeight = style({
-  prop: 'lineHeight',
-  key: 'lineHeights'
-})
+  prop: "lineHeight",
+  key: "lineHeights"
+});
 
 export const fontWeight = style({
-  prop: 'fontWeight',
-  key: 'fontWeights'
-})
+  prop: "fontWeight",
+  key: "fontWeights"
+});
 
 export const fontStyle = style({
-  prop: 'fontStyle'
-})
+  prop: "fontStyle"
+});
 
 export const letterSpacing = style({
-  prop: 'letterSpacing',
-  key: 'letterSpacings',
+  prop: "letterSpacing",
+  key: "letterSpacings",
   transformValue: px
-})
+});
 
 // layout
 export const display = style({
-  prop: 'display'
-})
+  prop: "display"
+});
 
 export const maxWidth = style({
-  prop: 'maxWidth',
-  key: 'maxWidths',
+  prop: "maxWidth",
+  key: "maxWidths",
   transformValue: px
-})
+});
 
 export const minWidth = style({
-  prop: 'minWidth',
-  key: 'minWidths',
+  prop: "minWidth",
+  key: "minWidths",
   transformValue: px
-})
+});
 
 export const height = style({
-  prop: 'height',
-  key: 'heights',
+  prop: "height",
+  key: "heights",
   transformValue: px
-})
+});
 
 export const maxHeight = style({
-  prop: 'maxHeight',
-  key: 'maxHeights',
+  prop: "maxHeight",
+  key: "maxHeights",
   transformValue: px
-})
+});
 
 export const minHeight = style({
-  prop: 'minHeight',
-  key: 'minHeights',
+  prop: "minHeight",
+  key: "minHeights",
   transformValue: px
-})
+});
 
 export const sizeWidth = style({
-  prop: 'size',
-  cssProperty: 'width',
+  prop: "size",
+  cssProperty: "width",
   transformValue: px
-})
+});
 
 export const sizeHeight = style({
-  prop: 'size',
-  cssProperty: 'height',
+  prop: "size",
+  cssProperty: "height",
   transformValue: px
-})
+});
 
 export const size = compose(
   sizeHeight,
   sizeWidth
-)
+);
 
 export const ratioPadding = style({
-  prop: 'ratio',
-  cssProperty: 'paddingBottom',
-  transformValue: n => (n * 100) + '%'
-})
+  prop: "ratio",
+  cssProperty: "paddingBottom",
+  transformValue: n => n * 100 + "%"
+});
 
-export const ratio = props => props.ratio ? ({
-  height: 0,
-  ...ratioPadding(props)
-}) : null
+export const ratio = props =>
+  props.ratio
+    ? {
+        height: 0,
+        ...ratioPadding(props)
+      }
+    : null;
 ratio.propTypes = {
   ...ratioPadding.propTypes
-}
+};
 
 export const verticalAlign = style({
-  prop: 'verticalAlign'
-})
+  prop: "verticalAlign"
+});
 
 // flexbox
 export const alignItems = style({
-  prop: 'alignItems'
-})
+  prop: "alignItems"
+});
 
 export const alignContent = style({
-  prop: 'alignContent'
-})
+  prop: "alignContent"
+});
 
 export const justifyItems = style({
-  prop: 'justifyItems'
-})
+  prop: "justifyItems"
+});
 
 export const justifyContent = style({
-  prop: 'justifyContent'
-})
+  prop: "justifyContent"
+});
 
 export const flexWrap = style({
-  prop: 'flexWrap'
-})
+  prop: "flexWrap"
+});
 
 export const flexBasis = style({
-  prop: 'flexBasis',
+  prop: "flexBasis",
   transformValue: getWidth
-})
-
+});
 
 export const flexDirection = style({
-  prop: 'flexDirection'
-})
+  prop: "flexDirection"
+});
 
 export const flex = style({
-  prop: 'flex'
-})
+  prop: "flex"
+});
 
 export const justifySelf = style({
-  prop: 'justifySelf'
-})
+  prop: "justifySelf"
+});
 
 export const alignSelf = style({
-  prop: 'alignSelf'
-})
+  prop: "alignSelf"
+});
 
 export const order = style({
-  prop: 'order'
-})
+  prop: "order"
+});
 
 // grid
 export const gridGap = style({
-  prop: 'gridGap',
+  prop: "gridGap",
   transformValue: px,
-  key: 'space'
-})
+  key: "space"
+});
 
 export const gridColumnGap = style({
-  prop: 'gridColumnGap',
+  prop: "gridColumnGap",
   transformValue: px,
-  key: 'space'
-})
+  key: "space"
+});
 
 export const gridRowGap = style({
-  prop: 'gridRowGap',
+  prop: "gridRowGap",
   transformValue: px,
-  key: 'space'
-})
+  key: "space"
+});
 
 export const gridColumn = style({
-  prop: 'gridColumn'
-})
+  prop: "gridColumn"
+});
 
 export const gridRow = style({
-  prop: 'gridRow'
-})
+  prop: "gridRow"
+});
 
 export const gridAutoFlow = style({
-  prop: 'gridAutoFlow'
-})
+  prop: "gridAutoFlow"
+});
 
 export const gridAutoColumns = style({
-  prop: 'gridAutoColumns'
-})
+  prop: "gridAutoColumns"
+});
 
 export const gridAutoRows = style({
-  prop: 'gridAutoRows'
-})
+  prop: "gridAutoRows"
+});
 
 export const gridTemplateColumns = style({
-  prop: 'gridTemplateColumns'
-})
+  prop: "gridTemplateColumns"
+});
 
 export const gridTemplateRows = style({
-  prop: 'gridTemplateRows'
-})
+  prop: "gridTemplateRows"
+});
 
 export const gridTemplateAreas = style({
-  prop: 'gridTemplateAreas'
-})
+  prop: "gridTemplateAreas"
+});
 
 export const gridArea = style({
-  prop: 'gridArea'
-})
+  prop: "gridArea"
+});
 
 // borders
-const getBorder = n => num(n) && n > 0 ? n + 'px solid' : n
+const getBorder = n => (num(n) && n > 0 ? n + "px solid" : n);
 
 export const border = style({
-  prop: 'border',
-  key: 'borders',
+  prop: "border",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borderTop = style({
-  prop: 'borderTop',
-  key: 'borders',
+  prop: "borderTop",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borderRight = style({
-  prop: 'borderRight',
-  key: 'borders',
+  prop: "borderRight",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borderBottom = style({
-  prop: 'borderBottom',
-  key: 'borders',
+  prop: "borderBottom",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borderLeft = style({
-  prop: 'borderLeft',
-  key: 'borders',
+  prop: "borderLeft",
+  key: "borders",
   transformValue: getBorder
-})
+});
 
 export const borders = compose(
   border,
@@ -532,96 +536,95 @@ export const borders = compose(
   borderRight,
   borderBottom,
   borderLeft
-)
+);
 
 export const borderColor = style({
-  prop: 'borderColor',
-  key: 'colors'
-})
+  prop: "borderColor",
+  key: "colors"
+});
 
 export const borderRadius = style({
-  prop: 'borderRadius',
-  key: 'radii',
-  transformValue: px,
-})
+  prop: "borderRadius",
+  key: "radii",
+  transformValue: px
+});
 
 export const boxShadow = style({
-  prop: 'boxShadow',
-  key: 'shadows'
-})
+  prop: "boxShadow",
+  key: "shadows"
+});
 
 export const opacity = style({
-  prop: 'opacity'
-})
+  prop: "opacity"
+});
 
 export const overflow = style({
-  prop: 'overflow'
-})
+  prop: "overflow"
+});
 
 // backgrounds
 export const background = style({
-  prop: 'background'
-})
+  prop: "background"
+});
 
 export const backgroundImage = style({
-  prop: 'backgroundImage'
-})
+  prop: "backgroundImage"
+});
 
 export const backgroundSize = style({
-  prop: 'backgroundSize'
-})
+  prop: "backgroundSize"
+});
 
 export const backgroundPosition = style({
-  prop: 'backgroundPosition'
-})
+  prop: "backgroundPosition"
+});
 
 export const backgroundRepeat = style({
-  prop: 'backgroundRepeat'
-})
+  prop: "backgroundRepeat"
+});
 
 // position
 export const position = style({
-  prop: 'position'
-})
+  prop: "position"
+});
 
 export const zIndex = style({
-  prop: 'zIndex'
-})
+  prop: "zIndex"
+});
 
 export const top = style({
-  prop: 'top',
+  prop: "top",
   transformValue: px
-})
+});
 
 export const right = style({
-  prop: 'right',
+  prop: "right",
   transformValue: px
-})
+});
 
 export const bottom = style({
-  prop: 'bottom',
+  prop: "bottom",
   transformValue: px
-})
+});
 
 export const left = style({
-  prop: 'left',
+  prop: "left",
   transformValue: px
-})
-
+});
 
 export const textStyle = variant({
-  prop: 'textStyle',
-  key: 'textStyles'
-})
+  prop: "textStyle",
+  key: "textStyles"
+});
 
 export const colorStyle = variant({
-  prop: 'colors',
-  key: 'colorStyles',
-})
+  prop: "colors",
+  key: "colorStyles"
+});
 
 export const buttonStyle = variant({
-  key: 'buttons'
-})
+  key: "buttons"
+});
 
 export const styles = {
   space,
@@ -696,29 +699,27 @@ export const styles = {
   left,
   textStyle,
   colorStyle,
-  buttonStyle,
-}
+  buttonStyle
+};
 
 // mixed
 const omit = (obj, blacklist) => {
-  const next = {}
+  const next = {};
   for (let key in obj) {
-    if (blacklist.indexOf(key) > -1) continue
-    next[key] = obj[key]
+    if (blacklist.indexOf(key) > -1) continue;
+    next[key] = obj[key];
   }
-  return next
-}
+  return next;
+};
 
 const funcs = Object.keys(styles)
   .map(key => styles[key])
-  .filter(fn => typeof fn === 'function')
+  .filter(fn => typeof fn === "function");
 
-const blacklist = funcs.reduce((a, fn) => [
-  ...a,
-  ...Object.keys(fn.propTypes || {})
-], [ 'theme' ])
+const blacklist = funcs.reduce(
+  (a, fn) => [...a, ...Object.keys(fn.propTypes || {})],
+  ["theme"]
+);
 
-
-export const mixed = props => funcs
-  .map(fn => fn(props))
-  .reduce(merge, omit(props, blacklist))
+export const mixed = props =>
+  funcs.map(fn => fn(props)).reduce(merge, omit(props, blacklist));

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
-import test from "ava";
-import * as system from "../src";
+import test from 'ava'
+import * as system from '../src'
 import {
   styles,
   space,
@@ -66,1195 +66,1195 @@ import {
   disabled,
   textStyle,
   colorStyle,
-  buttonStyle
-} from "../src";
+  buttonStyle,
+} from '../src'
 
 const theme = {
-  breakpoints: [32, 48, 64].map(n => n + "em"),
+  breakpoints: [32, 48, 64].map(n => n + 'em'),
   space: [0, 6, 12, 18, 24],
   fontSizes: [12, 16, 18, 24, 36, 72],
   radii: [2, 4],
   colors: {
-    blue: "#07c",
-    green: "#1c0",
-    gray: ["#ccc", "#555"]
-  }
-};
+    blue: '#07c',
+    green: '#1c0',
+    gray: ['#ccc', '#555'],
+  },
+}
 
 // aliases
-theme.space.big = 64;
-theme.fontSizes.big = 128;
+theme.space.big = 64
+theme.fontSizes.big = 128
 
-test("exports space, width, and fontSize", t => {
-  t.is(typeof space, "function");
-  t.is(typeof width, "function");
-  t.is(typeof fontSize, "function");
-});
+test('exports space, width, and fontSize', t => {
+  t.is(typeof space, 'function')
+  t.is(typeof width, 'function')
+  t.is(typeof fontSize, 'function')
+})
 
-test("themeGet gets theme values", t => {
-  const a = themeGet("colors.gray.0")({ theme });
-  t.is(a, theme.colors.gray[0]);
-});
+test('themeGet gets theme values', t => {
+  const a = themeGet('colors.gray.0')({ theme })
+  t.is(a, theme.colors.gray[0])
+})
 
-test("themeGet returns a fallback", t => {
-  const a = themeGet("colors.blue", "tomato")({ theme: {} });
-  t.is(a, "tomato");
-});
+test('themeGet returns a fallback', t => {
+  const a = themeGet('colors.blue', 'tomato')({ theme: {} })
+  t.is(a, 'tomato')
+})
 
-test.skip("themeGet returns declared 0 rather than undefined", t => {
-  const a = themeGet("space.0")({ theme });
-  t.is(a, 0);
-});
+test.skip('themeGet returns declared 0 rather than undefined', t => {
+  const a = themeGet('space.0')({ theme })
+  t.is(a, 0)
+})
 
 // util
-test("util.is checks for non null values", t => {
-  const a = util.is(null);
-  const b = util.is();
-  const c = util.is(0);
-  const d = util.is("");
-  const e = util.is(false);
-  const f = util.is([]);
-  t.false(a);
-  t.false(b);
-  t.true(c);
-  t.true(d);
-  t.true(e);
-  t.true(f);
-});
+test('util.is checks for non null values', t => {
+  const a = util.is(null)
+  const b = util.is()
+  const c = util.is(0)
+  const d = util.is('')
+  const e = util.is(false)
+  const f = util.is([])
+  t.false(a)
+  t.false(b)
+  t.true(c)
+  t.true(d)
+  t.true(e)
+  t.true(f)
+})
 
-test("util.px adds px unit to numbers", t => {
-  const a = util.px(1);
-  const b = util.px("2em");
-  t.is(a, "1px");
-  t.is(b, "2em");
-});
+test('util.px adds px unit to numbers', t => {
+  const a = util.px(1)
+  const b = util.px('2em')
+  t.is(a, '1px')
+  t.is(b, '2em')
+})
 
-test("util.num checks for a number", t => {
-  const a = util.num(1);
-  const b = util.num(0);
-  const c = util.num("1");
-  const d = util.num(null);
-  t.true(a);
-  t.true(b);
-  t.false(c);
-  t.false(d);
-});
+test('util.num checks for a number', t => {
+  const a = util.num(1)
+  const b = util.num(0)
+  const c = util.num('1')
+  const d = util.num(null)
+  t.true(a)
+  t.true(b)
+  t.false(c)
+  t.false(d)
+})
 
-test("util.merge reduces objects", t => {
+test('util.merge reduces objects', t => {
   const a = [
     {
-      a: "hello",
+      a: 'hello',
       b: {
-        beep: "boop"
-      }
+        beep: 'boop',
+      },
     },
     {
       b: {
-        hello: "hi"
-      }
-    }
-  ].reduce(util.merge, {});
+        hello: 'hi',
+      },
+    },
+  ].reduce(util.merge, {})
   t.deepEqual(a, {
-    a: "hello",
+    a: 'hello',
     b: {
-      beep: "boop",
-      hello: "hi"
-    }
-  });
-});
+      beep: 'boop',
+      hello: 'hi',
+    },
+  })
+})
 
-test("util.merge merges objects", t => {
+test('util.merge merges objects', t => {
   const a = util.merge(
     {
-      a: "hello",
+      a: 'hello',
       b: {
-        beep: "boop"
+        beep: 'boop',
       },
       c: {
         d: 2,
-        e: "f"
-      }
+        e: 'f',
+      },
     },
     {
       b: {
-        hello: "hi"
+        hello: 'hi',
       },
       c: {
-        g: 3
-      }
+        g: 3,
+      },
     }
-  );
+  )
   t.deepEqual(a, {
-    a: "hello",
+    a: 'hello',
     b: {
-      beep: "boop",
-      hello: "hi"
+      beep: 'boop',
+      hello: 'hi',
     },
     c: {
       d: 2,
-      e: "f",
-      g: 3
-    }
-  });
-});
+      e: 'f',
+      g: 3,
+    },
+  })
+})
 
-test("util.merge doesn’t throw with null values", t => {
+test('util.merge doesn’t throw with null values', t => {
   t.notThrows(() => {
-    util.merge(null, null);
-  });
-});
+    util.merge(null, null)
+  })
+})
 
-test("util.compose combines style functions", t => {
+test('util.compose combines style functions', t => {
   const combo = util.compose(
     display,
     width
-  );
-  const a = combo({ display: "inline-block", width: 1 / 2 });
+  )
+  const a = combo({ display: 'inline-block', width: 1 / 2 })
   t.deepEqual(a, {
-    display: "inline-block",
-    width: "50%"
-  });
-});
+    display: 'inline-block',
+    width: '50%',
+  })
+})
 
-test("util.get returns nested values", t => {
-  const value = util.get({ colors: { blue: "#07c" } }, "colors.blue");
-  t.is(value, "#07c");
-});
+test('util.get returns nested values', t => {
+  const value = util.get({ colors: { blue: '#07c' } }, 'colors.blue')
+  t.is(value, '#07c')
+})
 
 // space
-test("space returns margin declarations", t => {
-  const dec = space({ m: 1 });
-  t.deepEqual(dec, { margin: "4px" });
-});
+test('space returns margin declarations', t => {
+  const dec = space({ m: 1 })
+  t.deepEqual(dec, { margin: '4px' })
+})
 
-test("space returns non-scalar margins", t => {
-  const a = space({ m: 24 });
-  const b = space({ m: "auto" });
-  t.deepEqual(a, { margin: "24px" });
-  t.deepEqual(b, { margin: "auto" });
-});
+test('space returns non-scalar margins', t => {
+  const a = space({ m: 24 })
+  const b = space({ m: 'auto' })
+  t.deepEqual(a, { margin: '24px' })
+  t.deepEqual(b, { margin: 'auto' })
+})
 
-test("space returns keyed values", t => {
+test('space returns keyed values', t => {
   const a = space({
     theme: {
       space: {
         nested: {
-          big: theme.space.big
-        }
-      }
+          big: theme.space.big,
+        },
+      },
     },
-    m: "nested.big"
-  });
-  t.is(a.margin, theme.space.big + "px");
-});
+    m: 'nested.big',
+  })
+  t.is(a.margin, theme.space.big + 'px')
+})
 
-test("space returns negative margins", t => {
-  const a = space({ m: -1 });
-  const b = space({ m: -24 });
-  t.deepEqual(a, { margin: "-4px" });
-  t.deepEqual(b, { margin: "-24px" });
-});
+test('space returns negative margins', t => {
+  const a = space({ m: -1 })
+  const b = space({ m: -24 })
+  t.deepEqual(a, { margin: '-4px' })
+  t.deepEqual(b, { margin: '-24px' })
+})
 
-test("space returns directional margins", t => {
-  const top = space({ mt: 1 });
-  const r = space({ mr: 2 });
-  const b = space({ mb: 3 });
-  const l = space({ ml: 4 });
-  const x = space({ mx: 1 });
-  const y = space({ my: 2 });
-  t.deepEqual(top, { marginTop: "4px" });
-  t.deepEqual(r, { marginRight: "8px" });
-  t.deepEqual(b, { marginBottom: "16px" });
-  t.deepEqual(l, { marginLeft: "32px" });
-  t.deepEqual(x, { marginLeft: "4px", marginRight: "4px" });
-  t.deepEqual(y, { marginTop: "8px", marginBottom: "8px" });
-});
+test('space returns directional margins', t => {
+  const top = space({ mt: 1 })
+  const r = space({ mr: 2 })
+  const b = space({ mb: 3 })
+  const l = space({ ml: 4 })
+  const x = space({ mx: 1 })
+  const y = space({ my: 2 })
+  t.deepEqual(top, { marginTop: '4px' })
+  t.deepEqual(r, { marginRight: '8px' })
+  t.deepEqual(b, { marginBottom: '16px' })
+  t.deepEqual(l, { marginLeft: '32px' })
+  t.deepEqual(x, { marginLeft: '4px', marginRight: '4px' })
+  t.deepEqual(y, { marginTop: '8px', marginBottom: '8px' })
+})
 
-test("space returns responsive margins", t => {
-  const a = space({ m: [0, 1] });
+test('space returns responsive margins', t => {
+  const a = space({ m: [0, 1] })
   t.deepEqual(a, {
-    margin: "0px",
-    "@media screen and (min-width: 40em)": {
-      margin: "4px"
-    }
-  });
-});
+    margin: '0px',
+    '@media screen and (min-width: 40em)': {
+      margin: '4px',
+    },
+  })
+})
 
-test("space returns responsive directional margins", t => {
-  const a = space({ mt: [0, 1], mb: [2, 3] });
+test('space returns responsive directional margins', t => {
+  const a = space({ mt: [0, 1], mb: [2, 3] })
   t.deepEqual(a, {
-    marginBottom: "8px",
-    marginTop: "0px",
-    "@media screen and (min-width: 40em)": {
-      marginBottom: "16px",
-      marginTop: "4px"
-    }
-  });
-});
+    marginBottom: '8px',
+    marginTop: '0px',
+    '@media screen and (min-width: 40em)': {
+      marginBottom: '16px',
+      marginTop: '4px',
+    },
+  })
+})
 
-test("space sorts responsive directional margins", t => {
+test('space sorts responsive directional margins', t => {
   const a = space({
     mb: 2,
-    m: [0, 1]
-  });
-  const keys = Object.keys(a);
+    m: [0, 1],
+  })
+  const keys = Object.keys(a)
   t.deepEqual(keys, [
-    "margin",
-    "@media screen and (min-width: 40em)",
-    "marginBottom"
-  ]);
-});
+    'margin',
+    '@media screen and (min-width: 40em)',
+    'marginBottom',
+  ])
+})
 
-test("space returns padding declarations", t => {
-  const dec = space({ p: 1 });
-  t.deepEqual(dec, { padding: "4px" });
-});
+test('space returns padding declarations', t => {
+  const dec = space({ p: 1 })
+  t.deepEqual(dec, { padding: '4px' })
+})
 
-test("space returns non-scalar paddings", t => {
-  const a = space({ p: 24 });
-  const b = space({ p: "auto" });
-  t.deepEqual(a, { padding: "24px" });
-  t.deepEqual(b, { padding: "auto" });
-});
+test('space returns non-scalar paddings', t => {
+  const a = space({ p: 24 })
+  const b = space({ p: 'auto' })
+  t.deepEqual(a, { padding: '24px' })
+  t.deepEqual(b, { padding: 'auto' })
+})
 
-test("space returns directional paddings", t => {
-  const top = space({ pt: 1 });
-  const r = space({ pr: 2 });
-  const b = space({ pb: 3 });
-  const l = space({ pl: 4 });
-  const x = space({ px: 1 });
-  const y = space({ py: 2 });
-  t.deepEqual(top, { paddingTop: "4px" });
-  t.deepEqual(r, { paddingRight: "8px" });
-  t.deepEqual(b, { paddingBottom: "16px" });
-  t.deepEqual(l, { paddingLeft: "32px" });
-  t.deepEqual(x, { paddingLeft: "4px", paddingRight: "4px" });
-  t.deepEqual(y, { paddingTop: "8px", paddingBottom: "8px" });
-});
+test('space returns directional paddings', t => {
+  const top = space({ pt: 1 })
+  const r = space({ pr: 2 })
+  const b = space({ pb: 3 })
+  const l = space({ pl: 4 })
+  const x = space({ px: 1 })
+  const y = space({ py: 2 })
+  t.deepEqual(top, { paddingTop: '4px' })
+  t.deepEqual(r, { paddingRight: '8px' })
+  t.deepEqual(b, { paddingBottom: '16px' })
+  t.deepEqual(l, { paddingLeft: '32px' })
+  t.deepEqual(x, { paddingLeft: '4px', paddingRight: '4px' })
+  t.deepEqual(y, { paddingTop: '8px', paddingBottom: '8px' })
+})
 
-test("space returns responsive paddings", t => {
-  const a = space({ p: [0, 1] });
+test('space returns responsive paddings', t => {
+  const a = space({ p: [0, 1] })
   t.deepEqual(a, {
-    padding: "0px",
-    "@media screen and (min-width: 40em)": {
-      padding: "4px"
-    }
-  });
-});
+    padding: '0px',
+    '@media screen and (min-width: 40em)': {
+      padding: '4px',
+    },
+  })
+})
 
-test("space returns responsive directional paddings", t => {
-  const a = space({ pt: [0, 1], pb: [2, 3] });
+test('space returns responsive directional paddings', t => {
+  const a = space({ pt: [0, 1], pb: [2, 3] })
   t.deepEqual(a, {
-    paddingBottom: "8px",
-    paddingTop: "0px",
-    "@media screen and (min-width: 40em)": {
-      paddingBottom: "16px",
-      paddingTop: "4px"
-    }
-  });
-});
+    paddingBottom: '8px',
+    paddingTop: '0px',
+    '@media screen and (min-width: 40em)': {
+      paddingBottom: '16px',
+      paddingTop: '4px',
+    },
+  })
+})
 
-test("space can be configured with a theme", t => {
-  const a = space({ theme, m: 1 });
-  const b = space({ theme, m: 2 });
-  const c = space({ theme, m: 3 });
-  const d = space({ theme, m: 4 });
-  t.deepEqual(a, { margin: "6px" });
-  t.deepEqual(b, { margin: "12px" });
-  t.deepEqual(c, { margin: "18px" });
-  t.deepEqual(d, { margin: "24px" });
-});
+test('space can be configured with a theme', t => {
+  const a = space({ theme, m: 1 })
+  const b = space({ theme, m: 2 })
+  const c = space({ theme, m: 3 })
+  const d = space({ theme, m: 4 })
+  t.deepEqual(a, { margin: '6px' })
+  t.deepEqual(b, { margin: '12px' })
+  t.deepEqual(c, { margin: '18px' })
+  t.deepEqual(d, { margin: '24px' })
+})
 
-test("space can accept string values", t => {
-  const a = space({ theme: { space: ["1em", "2em"] }, m: 1 });
-  t.deepEqual(a, { margin: "2em" });
-});
+test('space can accept string values', t => {
+  const a = space({ theme: { space: ['1em', '2em'] }, m: 1 })
+  t.deepEqual(a, { margin: '2em' })
+})
 
-test("space can accept string values with negative", t => {
-  const a = space({ theme: { space: ["1em", "2em"] }, m: -1 });
-  t.deepEqual(a, { margin: "-2em" });
-});
+test('space can accept string values with negative', t => {
+  const a = space({ theme: { space: ['1em', '2em'] }, m: -1 })
+  t.deepEqual(a, { margin: '-2em' })
+})
 
-test("space handles null values in arrays", t => {
+test('space handles null values in arrays', t => {
   const a = space({
     m: [0, null, 2],
     theme: {
-      space: [0, 4, 8, 16]
-    }
-  });
+      space: [0, 4, 8, 16],
+    },
+  })
   t.deepEqual(a, {
-    margin: "0px",
-    "@media screen and (min-width: 52em)": {
-      margin: "8px"
-    }
-  });
-});
+    margin: '0px',
+    '@media screen and (min-width: 52em)': {
+      margin: '8px',
+    },
+  })
+})
 
-test("space can handle alias values", t => {
+test('space can handle alias values', t => {
   const a = space({
-    m: "large",
+    m: 'large',
     theme: {
       space: {
-        large: 12
-      }
-    }
-  });
-  t.deepEqual(a, { margin: "12px" });
-});
+        large: 12,
+      },
+    },
+  })
+  t.deepEqual(a, { margin: '12px' })
+})
 
 // width
-test("width returns percentage widths", t => {
-  const a = width({ width: 1 / 2 });
-  t.deepEqual(a, { width: "50%" });
-});
+test('width returns percentage widths', t => {
+  const a = width({ width: 1 / 2 })
+  t.deepEqual(a, { width: '50%' })
+})
 
-test("width returns pixel values", t => {
-  const a = width({ width: 256 });
-  t.deepEqual(a, { width: "256px" });
-});
+test('width returns pixel values', t => {
+  const a = width({ width: 256 })
+  t.deepEqual(a, { width: '256px' })
+})
 
-test("width returns string values", t => {
-  const a = width({ width: "auto" });
-  t.deepEqual(a, { width: "auto" });
-});
+test('width returns string values', t => {
+  const a = width({ width: 'auto' })
+  t.deepEqual(a, { width: 'auto' })
+})
 
-test("width returns responsive values", t => {
-  const a = width({ width: [1, 1 / 2] });
+test('width returns responsive values', t => {
+  const a = width({ width: [1, 1 / 2] })
   t.deepEqual(a, {
-    width: "100%",
-    "@media screen and (min-width: 40em)": { width: "50%" }
-  });
-});
+    width: '100%',
+    '@media screen and (min-width: 40em)': { width: '50%' },
+  })
+})
 
-test("width returns responsive pixel values", t => {
-  const a = width({ width: [128, 256] });
+test('width returns responsive pixel values', t => {
+  const a = width({ width: [128, 256] })
   t.deepEqual(a, {
-    width: "128px",
-    "@media screen and (min-width: 40em)": { width: "256px" }
-  });
-});
+    width: '128px',
+    '@media screen and (min-width: 40em)': { width: '256px' },
+  })
+})
 
-test("width returns 0 value", t => {
-  const a = width({ width: 0 });
-  t.deepEqual(a, { width: "0%" });
-});
+test('width returns 0 value', t => {
+  const a = width({ width: 0 })
+  t.deepEqual(a, { width: '0%' })
+})
 
-test("width returns null ", t => {
-  const a = width({});
-  t.is(a, null);
-});
+test('width returns null ', t => {
+  const a = width({})
+  t.is(a, null)
+})
 
 // fontSize
-test("fontSize returns scale values", t => {
-  const a = fontSize({ fontSize: 0, theme: {} });
-  const b = fontSize({ fontSize: 1, theme: {} });
-  const c = fontSize({ fontSize: 2 });
-  t.deepEqual(a, { fontSize: "12px" });
-  t.deepEqual(b, { fontSize: "14px" });
-  t.deepEqual(c, { fontSize: "16px" });
-});
+test('fontSize returns scale values', t => {
+  const a = fontSize({ fontSize: 0, theme: {} })
+  const b = fontSize({ fontSize: 1, theme: {} })
+  const c = fontSize({ fontSize: 2 })
+  t.deepEqual(a, { fontSize: '12px' })
+  t.deepEqual(b, { fontSize: '14px' })
+  t.deepEqual(c, { fontSize: '16px' })
+})
 
-test("fontSize returns keyed values", t => {
+test('fontSize returns keyed values', t => {
   const a = fontSize({
     theme,
-    fontSize: "big"
-  });
-  t.is(a.fontSize, theme.fontSizes.big + "px");
-});
+    fontSize: 'big',
+  })
+  t.is(a.fontSize, theme.fontSizes.big + 'px')
+})
 
-test("fontSize returns pixel values", t => {
-  const a = fontSize({ fontSize: 24 });
-  t.deepEqual(a, { fontSize: "24px" });
-});
+test('fontSize returns pixel values', t => {
+  const a = fontSize({ fontSize: 24 })
+  t.deepEqual(a, { fontSize: '24px' })
+})
 
-test("fontSize returns string values", t => {
-  const a = fontSize({ fontSize: "2em" });
-  t.deepEqual(a, { fontSize: "2em" });
-});
+test('fontSize returns string values', t => {
+  const a = fontSize({ fontSize: '2em' })
+  t.deepEqual(a, { fontSize: '2em' })
+})
 
-test("fontSize returns responsive values", t => {
-  const a = fontSize({ fontSize: [1, 2] });
+test('fontSize returns responsive values', t => {
+  const a = fontSize({ fontSize: [1, 2] })
   t.deepEqual(a, {
-    fontSize: "14px",
-    "@media screen and (min-width: 40em)": {
-      fontSize: "16px"
-    }
-  });
-});
+    fontSize: '14px',
+    '@media screen and (min-width: 40em)': {
+      fontSize: '16px',
+    },
+  })
+})
 
-test("fontSize can be configured with a theme", t => {
-  const a = fontSize({ theme, fontSize: 0 });
-  const b = fontSize({ theme, fontSize: 1 });
-  const c = fontSize({ theme, fontSize: 2 });
-  const d = fontSize({ theme, fontSize: 3 });
-  const e = fontSize({ theme, fontSize: 4 });
-  const f = fontSize({ theme, fontSize: 5 });
-  t.deepEqual(a, { fontSize: "12px" });
-  t.deepEqual(b, { fontSize: "16px" });
-  t.deepEqual(c, { fontSize: "18px" });
-  t.deepEqual(d, { fontSize: "24px" });
-  t.deepEqual(e, { fontSize: "36px" });
-  t.deepEqual(f, { fontSize: "72px" });
-});
+test('fontSize can be configured with a theme', t => {
+  const a = fontSize({ theme, fontSize: 0 })
+  const b = fontSize({ theme, fontSize: 1 })
+  const c = fontSize({ theme, fontSize: 2 })
+  const d = fontSize({ theme, fontSize: 3 })
+  const e = fontSize({ theme, fontSize: 4 })
+  const f = fontSize({ theme, fontSize: 5 })
+  t.deepEqual(a, { fontSize: '12px' })
+  t.deepEqual(b, { fontSize: '16px' })
+  t.deepEqual(c, { fontSize: '18px' })
+  t.deepEqual(d, { fontSize: '24px' })
+  t.deepEqual(e, { fontSize: '36px' })
+  t.deepEqual(f, { fontSize: '72px' })
+})
 
-test("fontSize returns null", t => {
-  const a = fontSize({});
-  t.is(a, null);
-});
+test('fontSize returns null', t => {
+  const a = fontSize({})
+  t.is(a, null)
+})
 
 // color
-test("color returns color and backgroundColor styles", t => {
-  const a = color({ color: "tomato" });
-  const b = color({ bg: "tomato" });
-  t.deepEqual(a, { color: "tomato" });
-  t.deepEqual(b, { backgroundColor: "tomato" });
-});
+test('color returns color and backgroundColor styles', t => {
+  const a = color({ color: 'tomato' })
+  const b = color({ bg: 'tomato' })
+  t.deepEqual(a, { color: 'tomato' })
+  t.deepEqual(b, { backgroundColor: 'tomato' })
+})
 
-test("color returns theme.colors values", t => {
-  const a = color({ theme, color: "blue" });
-  const b = color({ theme, bg: "green" });
-  t.deepEqual(a, { color: theme.colors.blue });
-  t.deepEqual(b, { backgroundColor: theme.colors.green });
-});
+test('color returns theme.colors values', t => {
+  const a = color({ theme, color: 'blue' })
+  const b = color({ theme, bg: 'green' })
+  t.deepEqual(a, { color: theme.colors.blue })
+  t.deepEqual(b, { backgroundColor: theme.colors.green })
+})
 
-test("color returns responsive values", t => {
-  const a = color({ theme, color: ["blue", "green"] });
+test('color returns responsive values', t => {
+  const a = color({ theme, color: ['blue', 'green'] })
   t.deepEqual(a, {
     color: theme.colors.blue,
-    "@media screen and (min-width: 32em)": {
-      color: theme.colors.green
-    }
-  });
-});
+    '@media screen and (min-width: 32em)': {
+      color: theme.colors.green,
+    },
+  })
+})
 
-test("color works with array theme.colors", t => {
+test('color works with array theme.colors', t => {
   const a = color({
     theme: {
-      colors: ["tomato", "plum"]
+      colors: ['tomato', 'plum'],
     },
-    color: 0
-  });
-  t.is(a.color, "tomato");
-});
+    color: 0,
+  })
+  t.is(a.color, 'tomato')
+})
 
-test("color keys support dot notation", t => {
+test('color keys support dot notation', t => {
   const a = color({
     theme: {
       colors: {
-        gray: ["#333", "#666", "#999"]
-      }
+        gray: ['#333', '#666', '#999'],
+      },
     },
-    color: "gray.2"
-  });
-  t.is(a.color, "#999");
-});
+    color: 'gray.2',
+  })
+  t.is(a.color, '#999')
+})
 
 // style
-test("style returns a function", t => {
+test('style returns a function', t => {
   const sx = style({
-    prop: "color",
-    key: "colors"
-  });
-  t.is(typeof sx, "function");
-});
+    prop: 'color',
+    key: 'colors',
+  })
+  t.is(typeof sx, 'function')
+})
 
-test("style function returns a style object", t => {
+test('style function returns a style object', t => {
   const a = style({
-    prop: "color",
-    key: "colors"
-  })({ color: "tomato" });
-  t.is(typeof a, "object");
-  t.deepEqual(a, { color: "tomato" });
-});
+    prop: 'color',
+    key: 'colors',
+  })({ color: 'tomato' })
+  t.is(typeof a, 'object')
+  t.deepEqual(a, { color: 'tomato' })
+})
 
-test("style function returns null", t => {
+test('style function returns null', t => {
   const sx = style({
-    prop: "color"
-  });
-  const a = sx({});
-  t.is(a, null);
-});
+    prop: 'color',
+  })
+  const a = sx({})
+  t.is(a, null)
+})
 
-test("style function returns scale values", t => {
+test('style function returns scale values', t => {
   const sx = style({
-    key: "colors",
-    prop: "color"
-  });
+    key: 'colors',
+    prop: 'color',
+  })
   const a = sx({
-    color: "blue",
+    color: 'blue',
     theme: {
       colors: {
-        blue: "#07c"
-      }
-    }
-  });
-  t.is(a.color, "#07c");
-});
-
-test("style function returns pixels for number values", t => {
-  const sx = style({
-    prop: "borderRadius",
-    transformValue: util.px
-  });
-  const a = sx({
-    borderRadius: 4,
-    theme: {}
-  });
-  t.is(a.borderRadius, "4px");
-});
-
-test("style function returns unitless number values", t => {
-  const sx = style({
-    prop: "borderRadius"
-  });
-  const a = sx({
-    borderRadius: 4,
-    theme: {}
-  });
-  t.is(a.borderRadius, 4);
-});
-
-test("style function accepts a transformValue option", t => {
-  const sx = style({
-    prop: "width",
-    transformValue: n => (!util.num(n) || n > 1 ? util.px(n) : n * 100 + "%")
-  });
-  const a = sx({ width: 1 / 2 });
-  const b = sx({ width: 24 });
-  t.is(a.width, "50%");
-  t.is(b.width, "24px");
-});
-
-test("style allows property aliases", t => {
-  const direction = style({
-    cssProperty: "flex-direction",
-    prop: "direction"
-  });
-  const a = direction({ direction: "column" });
-  t.deepEqual(a, {
-    "flex-direction": "column"
-  });
-});
-
-test("style allows array values", t => {
-  const direction = style({
-    cssProperty: "flex-direction",
-    prop: "direction"
-  });
-  const a = direction({ direction: ["column", null, "row"] });
-  t.deepEqual(a, {
-    "flex-direction": "column",
-    "@media screen and (min-width: 52em)": {
-      "flex-direction": "row"
-    }
-  });
-});
-
-test("style returns pixel values for number arrays", t => {
-  const radius = style({
-    cssProperty: "borderRadius",
-    prop: "radius",
-    transformValue: util.px
-  });
-  const a = radius({ radius: [4, 5, 6] });
-  t.deepEqual(a, {
-    borderRadius: "4px",
-    "@media screen and (min-width: 40em)": {
-      borderRadius: "5px"
+        blue: '#07c',
+      },
     },
-    "@media screen and (min-width: 52em)": {
-      borderRadius: "6px"
-    }
-  });
-});
+  })
+  t.is(a.color, '#07c')
+})
 
-test("style returns a theme value", t => {
+test('style function returns pixels for number values', t => {
   const sx = style({
-    prop: "borderColor",
-    key: "colors"
-  });
+    prop: 'borderRadius',
+    transformValue: util.px,
+  })
+  const a = sx({
+    borderRadius: 4,
+    theme: {},
+  })
+  t.is(a.borderRadius, '4px')
+})
+
+test('style function returns unitless number values', t => {
+  const sx = style({
+    prop: 'borderRadius',
+  })
+  const a = sx({
+    borderRadius: 4,
+    theme: {},
+  })
+  t.is(a.borderRadius, 4)
+})
+
+test('style function accepts a transformValue option', t => {
+  const sx = style({
+    prop: 'width',
+    transformValue: n => (!util.num(n) || n > 1 ? util.px(n) : n * 100 + '%'),
+  })
+  const a = sx({ width: 1 / 2 })
+  const b = sx({ width: 24 })
+  t.is(a.width, '50%')
+  t.is(b.width, '24px')
+})
+
+test('style allows property aliases', t => {
+  const direction = style({
+    cssProperty: 'flex-direction',
+    prop: 'direction',
+  })
+  const a = direction({ direction: 'column' })
+  t.deepEqual(a, {
+    'flex-direction': 'column',
+  })
+})
+
+test('style allows array values', t => {
+  const direction = style({
+    cssProperty: 'flex-direction',
+    prop: 'direction',
+  })
+  const a = direction({ direction: ['column', null, 'row'] })
+  t.deepEqual(a, {
+    'flex-direction': 'column',
+    '@media screen and (min-width: 52em)': {
+      'flex-direction': 'row',
+    },
+  })
+})
+
+test('style returns pixel values for number arrays', t => {
+  const radius = style({
+    cssProperty: 'borderRadius',
+    prop: 'radius',
+    transformValue: util.px,
+  })
+  const a = radius({ radius: [4, 5, 6] })
+  t.deepEqual(a, {
+    borderRadius: '4px',
+    '@media screen and (min-width: 40em)': {
+      borderRadius: '5px',
+    },
+    '@media screen and (min-width: 52em)': {
+      borderRadius: '6px',
+    },
+  })
+})
+
+test('style returns a theme value', t => {
+  const sx = style({
+    prop: 'borderColor',
+    key: 'colors',
+  })
   const a = sx({
     theme,
-    borderColor: ["blue", "green"]
-  });
+    borderColor: ['blue', 'green'],
+  })
   t.deepEqual(a, {
     borderColor: theme.colors.blue,
-    "@media screen and (min-width: 32em)": {
-      borderColor: theme.colors.green
-    }
-  });
-});
+    '@media screen and (min-width: 32em)': {
+      borderColor: theme.colors.green,
+    },
+  })
+})
 
-test("style returns a theme number value in px", t => {
+test('style returns a theme number value in px', t => {
   const sx = style({
-    prop: "borderRadius",
-    key: "radii",
-    transformValue: util.px
-  });
+    prop: 'borderRadius',
+    key: 'radii',
+    transformValue: util.px,
+  })
   const a = sx({
     theme,
-    borderRadius: [0, 1]
-  });
+    borderRadius: [0, 1],
+  })
   t.deepEqual(a, {
-    borderRadius: theme.radii[0] + "px",
-    "@media screen and (min-width: 32em)": {
-      borderRadius: theme.radii[1] + "px"
-    }
-  });
-});
+    borderRadius: theme.radii[0] + 'px',
+    '@media screen and (min-width: 32em)': {
+      borderRadius: theme.radii[1] + 'px',
+    },
+  })
+})
 
 // theme
-test("breakpoints can be configured with a theme", t => {
-  const a = space({ theme, m: [1, 2, 3, 4] });
-  const [, b, c, d] = Object.keys(a);
-  t.is(b, "@media screen and (min-width: 32em)");
-  t.is(c, "@media screen and (min-width: 48em)");
-  t.is(d, "@media screen and (min-width: 64em)");
-});
+test('breakpoints can be configured with a theme', t => {
+  const a = space({ theme, m: [1, 2, 3, 4] })
+  const [, b, c, d] = Object.keys(a)
+  t.is(b, '@media screen and (min-width: 32em)')
+  t.is(c, '@media screen and (min-width: 48em)')
+  t.is(d, '@media screen and (min-width: 64em)')
+})
 
 // textAlign
-test("textAlign returns text-align", t => {
-  const a = textAlign({ textAlign: "center" });
-  t.deepEqual(a, { textAlign: "center" });
-});
+test('textAlign returns text-align', t => {
+  const a = textAlign({ textAlign: 'center' })
+  t.deepEqual(a, { textAlign: 'center' })
+})
 
-test("textAlign returns responsive text-align", t => {
-  const a = textAlign({ textAlign: ["center", "left"] });
+test('textAlign returns responsive text-align', t => {
+  const a = textAlign({ textAlign: ['center', 'left'] })
   t.deepEqual(a, {
-    textAlign: "center",
-    "@media screen and (min-width: 40em)": {
-      textAlign: "left"
-    }
-  });
-});
+    textAlign: 'center',
+    '@media screen and (min-width: 40em)': {
+      textAlign: 'left',
+    },
+  })
+})
 
-test("fontFamily returns font-family", t => {
-  const a = fontFamily({ fontFamily: "system-ui" });
-  t.is(a.fontFamily, "system-ui");
-});
+test('fontFamily returns font-family', t => {
+  const a = fontFamily({ fontFamily: 'system-ui' })
+  t.is(a.fontFamily, 'system-ui')
+})
 
 // lineHeight
-test("lineHeight returns line-height", t => {
-  const a = lineHeight({ lineHeight: 1.23 });
-  t.deepEqual(a, { lineHeight: 1.23 });
-});
+test('lineHeight returns line-height', t => {
+  const a = lineHeight({ lineHeight: 1.23 })
+  t.deepEqual(a, { lineHeight: 1.23 })
+})
 
-test("lineHeight returns a scalar style", t => {
+test('lineHeight returns a scalar style', t => {
   const a = lineHeight({
     theme: {
-      lineHeights: [1, 2, 3]
+      lineHeights: [1, 2, 3],
     },
-    lineHeight: 1
-  });
+    lineHeight: 1,
+  })
 
-  t.deepEqual(a, { lineHeight: 2 });
-});
+  t.deepEqual(a, { lineHeight: 2 })
+})
 
-test("lineHeight returns responsive line-height", t => {
+test('lineHeight returns responsive line-height', t => {
   const a = lineHeight({
     theme: {
-      lineHeights: [1, 2, 3]
+      lineHeights: [1, 2, 3],
     },
-    lineHeight: [1, 2]
-  });
+    lineHeight: [1, 2],
+  })
 
   t.deepEqual(a, {
     lineHeight: 2,
-    "@media screen and (min-width: 40em)": {
-      lineHeight: 3
-    }
-  });
-});
+    '@media screen and (min-width: 40em)': {
+      lineHeight: 3,
+    },
+  })
+})
 
 // fontWeight
-test("fontWeight returns fontWeight", t => {
-  const a = fontWeight({ fontWeight: "bold" });
-  t.deepEqual(a, { fontWeight: "bold" });
-});
+test('fontWeight returns fontWeight', t => {
+  const a = fontWeight({ fontWeight: 'bold' })
+  t.deepEqual(a, { fontWeight: 'bold' })
+})
 
-test("fontWeight returns a scalar style", t => {
+test('fontWeight returns a scalar style', t => {
   const a = fontWeight({
     theme: {
-      fontWeights: [400, 600, 800]
+      fontWeights: [400, 600, 800],
     },
-    fontWeight: 2
-  });
-  t.deepEqual(a, { fontWeight: 800 });
-});
+    fontWeight: 2,
+  })
+  t.deepEqual(a, { fontWeight: 800 })
+})
 
 // letterSpacing
-test("letterSpacing returns letterSpacing", t => {
-  const a = letterSpacing({ letterSpacing: 2 });
-  t.deepEqual(a, { letterSpacing: "2px" });
-});
+test('letterSpacing returns letterSpacing', t => {
+  const a = letterSpacing({ letterSpacing: 2 })
+  t.deepEqual(a, { letterSpacing: '2px' })
+})
 
-test("letterSpacing returns a scalar style", t => {
+test('letterSpacing returns a scalar style', t => {
   const a = letterSpacing({
     theme: {
-      letterSpacings: [1, 2, 3]
+      letterSpacings: [1, 2, 3],
     },
-    letterSpacing: 2
-  });
-  t.deepEqual(a, { letterSpacing: "3px" });
-});
+    letterSpacing: 2,
+  })
+  t.deepEqual(a, { letterSpacing: '3px' })
+})
 
-test("display returns display", t => {
-  const a = display({ display: "inline-block" });
-  t.is(a.display, "inline-block");
-});
+test('display returns display', t => {
+  const a = display({ display: 'inline-block' })
+  t.is(a.display, 'inline-block')
+})
 
-test("minWidth returns minWidth", t => {
-  const a = minWidth({ minWidth: 256 });
-  t.is(a.minWidth, "256px");
-});
+test('minWidth returns minWidth', t => {
+  const a = minWidth({ minWidth: 256 })
+  t.is(a.minWidth, '256px')
+})
 
-test("maxWidth returns width styles", t => {
-  const a = maxWidth({ maxWidth: 234 });
-  t.deepEqual(a, { maxWidth: "234px" });
-});
+test('maxWidth returns width styles', t => {
+  const a = maxWidth({ maxWidth: 234 })
+  t.deepEqual(a, { maxWidth: '234px' })
+})
 
-test("maxWidth returns null when blank", t => {
-  const a = maxWidth({ maxWidth: null });
-  t.is(a, null);
-});
+test('maxWidth returns null when blank', t => {
+  const a = maxWidth({ maxWidth: null })
+  t.is(a, null)
+})
 
-test("maxWidth returns scalar styles", t => {
+test('maxWidth returns scalar styles', t => {
   const a = maxWidth({
     theme: {
-      maxWidths: [123, 456, 789]
+      maxWidths: [123, 456, 789],
     },
-    maxWidth: 1
-  });
-  t.deepEqual(a, { maxWidth: "456px" });
-});
+    maxWidth: 1,
+  })
+  t.deepEqual(a, { maxWidth: '456px' })
+})
 
-test("height returns height", t => {
-  const a = height({ height: 256 });
-  t.is(a.height, "256px");
-});
+test('height returns height', t => {
+  const a = height({ height: 256 })
+  t.is(a.height, '256px')
+})
 
-test("minHeight returns minHeight", t => {
-  const a = minHeight({ minHeight: 256 });
-  t.is(a.minHeight, "256px");
-});
+test('minHeight returns minHeight', t => {
+  const a = minHeight({ minHeight: 256 })
+  t.is(a.minHeight, '256px')
+})
 
-test("maxHeight returns maxHeight", t => {
-  const a = maxHeight({ maxHeight: 256 });
-  t.is(a.maxHeight, "256px");
-});
+test('maxHeight returns maxHeight', t => {
+  const a = maxHeight({ maxHeight: 256 })
+  t.is(a.maxHeight, '256px')
+})
 
-test("size returns width and height", t => {
-  const a = size({ size: 256 });
-  t.is(a.width, "256px");
-  t.is(a.height, "256px");
-});
+test('size returns width and height', t => {
+  const a = size({ size: 256 })
+  t.is(a.width, '256px')
+  t.is(a.height, '256px')
+})
 
-test("ratio returns height and paddingBottom", t => {
-  const a = ratio({ ratio: 1 / 2 });
-  t.is(a.height, 0);
-  t.is(a.paddingBottom, "50%");
-});
+test('ratio returns height and paddingBottom', t => {
+  const a = ratio({ ratio: 1 / 2 })
+  t.is(a.height, 0)
+  t.is(a.paddingBottom, '50%')
+})
 
-test("ratio returns null when undefined", t => {
-  const a = ratio({});
-  t.is(a, null);
-});
+test('ratio returns null when undefined', t => {
+  const a = ratio({})
+  t.is(a, null)
+})
 
-test("verticalAlign returns verticalAlign", t => {
-  const a = verticalAlign({ verticalAlign: "middle" });
+test('verticalAlign returns verticalAlign', t => {
+  const a = verticalAlign({ verticalAlign: 'middle' })
   t.deepEqual(a, {
-    verticalAlign: "middle"
-  });
-});
+    verticalAlign: 'middle',
+  })
+})
 
-test("alignItems returns a style", t => {
-  const a = alignItems({ alignItems: "center" });
-  t.deepEqual(a, { alignItems: "center" });
-});
+test('alignItems returns a style', t => {
+  const a = alignItems({ alignItems: 'center' })
+  t.deepEqual(a, { alignItems: 'center' })
+})
 
-test("alignContent returns a style", t => {
-  const a = alignContent({ alignContent: "center" });
-  t.deepEqual(a, { alignContent: "center" });
-});
+test('alignContent returns a style', t => {
+  const a = alignContent({ alignContent: 'center' })
+  t.deepEqual(a, { alignContent: 'center' })
+})
 
-test("justifyContent returns a style", t => {
-  const a = justifyContent({ justifyContent: "center" });
-  t.deepEqual(a, { justifyContent: "center" });
-});
+test('justifyContent returns a style', t => {
+  const a = justifyContent({ justifyContent: 'center' })
+  t.deepEqual(a, { justifyContent: 'center' })
+})
 
-test("flexWrap returns a style", t => {
-  const a = flexWrap({ flexWrap: "wrap" });
-  t.deepEqual(a, { flexWrap: "wrap" });
-});
+test('flexWrap returns a style', t => {
+  const a = flexWrap({ flexWrap: 'wrap' })
+  t.deepEqual(a, { flexWrap: 'wrap' })
+})
 
-test("flexDirection returns a style", t => {
-  const a = flexDirection({ flexDirection: "column" });
-  t.deepEqual(a, { flexDirection: "column" });
-});
+test('flexDirection returns a style', t => {
+  const a = flexDirection({ flexDirection: 'column' })
+  t.deepEqual(a, { flexDirection: 'column' })
+})
 
-test("flex returns a style", t => {
-  const a = flex({ flex: "none" });
-  t.deepEqual(a, { flex: "none" });
-});
+test('flex returns a style', t => {
+  const a = flex({ flex: 'none' })
+  t.deepEqual(a, { flex: 'none' })
+})
 
-test("justifySelf returns a style", t => {
-  const a = justifySelf({ justifySelf: "center" });
-  t.deepEqual(a, { justifySelf: "center" });
-});
+test('justifySelf returns a style', t => {
+  const a = justifySelf({ justifySelf: 'center' })
+  t.deepEqual(a, { justifySelf: 'center' })
+})
 
-test("alignSelf returns a style", t => {
-  const a = alignSelf({ alignSelf: "center" });
-  t.deepEqual(a, { alignSelf: "center" });
-});
+test('alignSelf returns a style', t => {
+  const a = alignSelf({ alignSelf: 'center' })
+  t.deepEqual(a, { alignSelf: 'center' })
+})
 
-test("order returns a style", t => {
-  const a = order({ order: 2 });
-  t.deepEqual(a, { order: 2 });
-});
+test('order returns a style', t => {
+  const a = order({ order: 2 })
+  t.deepEqual(a, { order: 2 })
+})
 
-test("gridGap returns a scalar style", t => {
+test('gridGap returns a scalar style', t => {
   const a = gridGap({
     theme: {
-      space: [0, 2, 4, 8]
+      space: [0, 2, 4, 8],
     },
-    gridGap: 3
-  });
+    gridGap: 3,
+  })
 
-  t.deepEqual(a, { gridGap: "8px" });
-});
+  t.deepEqual(a, { gridGap: '8px' })
+})
 
-test("gridRowGap returns a scalar style", t => {
+test('gridRowGap returns a scalar style', t => {
   const a = gridRowGap({
     theme: {
-      space: [0, 2, 4, 8]
+      space: [0, 2, 4, 8],
     },
-    gridRowGap: 3
-  });
+    gridRowGap: 3,
+  })
 
-  t.deepEqual(a, { gridRowGap: "8px" });
-});
+  t.deepEqual(a, { gridRowGap: '8px' })
+})
 
-test("gridColumnGap returns a scalar style", t => {
+test('gridColumnGap returns a scalar style', t => {
   const a = gridColumnGap({
     theme: {
-      space: [0, 2, 4, 8]
+      space: [0, 2, 4, 8],
     },
-    gridColumnGap: 3
-  });
+    gridColumnGap: 3,
+  })
 
-  t.deepEqual(a, { gridColumnGap: "8px" });
-});
+  t.deepEqual(a, { gridColumnGap: '8px' })
+})
 
-test("gridAutoFlow returns a style", t => {
-  const a = gridAutoFlow({ gridAutoFlow: "row dense" });
-  t.deepEqual(a, { gridAutoFlow: "row dense" });
-});
+test('gridAutoFlow returns a style', t => {
+  const a = gridAutoFlow({ gridAutoFlow: 'row dense' })
+  t.deepEqual(a, { gridAutoFlow: 'row dense' })
+})
 
-test("gridAutoRows returns a style", t => {
-  const a = gridAutoRows({ gridAutoRows: "auto" });
-  t.deepEqual(a, { gridAutoRows: "auto" });
-});
+test('gridAutoRows returns a style', t => {
+  const a = gridAutoRows({ gridAutoRows: 'auto' })
+  t.deepEqual(a, { gridAutoRows: 'auto' })
+})
 
-test("gridAutoColumns returns a style", t => {
-  const a = gridAutoColumns({ gridAutoColumns: "auto" });
-  t.deepEqual(a, { gridAutoColumns: "auto" });
-});
+test('gridAutoColumns returns a style', t => {
+  const a = gridAutoColumns({ gridAutoColumns: 'auto' })
+  t.deepEqual(a, { gridAutoColumns: 'auto' })
+})
 
-test("gridTemplateColumns returns a style", t => {
-  const a = gridTemplateColumns({ gridTemplateColumns: "1fr 1fr" });
-  t.deepEqual(a, { gridTemplateColumns: "1fr 1fr" });
-});
+test('gridTemplateColumns returns a style', t => {
+  const a = gridTemplateColumns({ gridTemplateColumns: '1fr 1fr' })
+  t.deepEqual(a, { gridTemplateColumns: '1fr 1fr' })
+})
 
-test("gridTemplateRows returns a style", t => {
-  const a = gridTemplateRows({ gridTemplateRows: "1fr 1fr" });
-  t.deepEqual(a, { gridTemplateRows: "1fr 1fr" });
-});
+test('gridTemplateRows returns a style', t => {
+  const a = gridTemplateRows({ gridTemplateRows: '1fr 1fr' })
+  t.deepEqual(a, { gridTemplateRows: '1fr 1fr' })
+})
 
-test("gridColumn returns a style", t => {
-  const a = gridColumn({ gridColumn: "span 2" });
-  t.deepEqual(a, { gridColumn: "span 2" });
-});
+test('gridColumn returns a style', t => {
+  const a = gridColumn({ gridColumn: 'span 2' })
+  t.deepEqual(a, { gridColumn: 'span 2' })
+})
 
-test("gridRow returns a style", t => {
-  const a = gridRow({ gridRow: "span 2" });
-  t.deepEqual(a, { gridRow: "span 2" });
-});
+test('gridRow returns a style', t => {
+  const a = gridRow({ gridRow: 'span 2' })
+  t.deepEqual(a, { gridRow: 'span 2' })
+})
 
-test("borderRadius returns borderRadius", t => {
-  const a = borderRadius({ borderRadius: "4px" });
-  t.deepEqual(a, { borderRadius: "4px" });
-});
+test('borderRadius returns borderRadius', t => {
+  const a = borderRadius({ borderRadius: '4px' })
+  t.deepEqual(a, { borderRadius: '4px' })
+})
 
-test("borderRadius returns a pixel value", t => {
-  const a = borderRadius({ borderRadius: 4 });
-  t.deepEqual(a, { borderRadius: "4px" });
-});
+test('borderRadius returns a pixel value', t => {
+  const a = borderRadius({ borderRadius: 4 })
+  t.deepEqual(a, { borderRadius: '4px' })
+})
 
-test("borderRadius returns a pixel value from theme", t => {
+test('borderRadius returns a pixel value from theme', t => {
   const a = borderRadius({
     theme,
-    borderRadius: 0
-  });
-  t.deepEqual(a, { borderRadius: "2px" });
-});
+    borderRadius: 0,
+  })
+  t.deepEqual(a, { borderRadius: '2px' })
+})
 
-test("borderColor returns borderColor", t => {
-  const a = borderColor({ borderColor: "blue" });
-  t.deepEqual(a, { borderColor: "blue" });
-});
+test('borderColor returns borderColor', t => {
+  const a = borderColor({ borderColor: 'blue' })
+  t.deepEqual(a, { borderColor: 'blue' })
+})
 
-test("borderColor returns nested borderColor", t => {
-  const a = borderColor({ theme, borderColor: "gray.0" });
-  t.deepEqual(a, { borderColor: theme.colors.gray[0] });
-});
+test('borderColor returns nested borderColor', t => {
+  const a = borderColor({ theme, borderColor: 'gray.0' })
+  t.deepEqual(a, { borderColor: theme.colors.gray[0] })
+})
 
-test("borders returns a border shorthand style", t => {
-  const a = borders({ border: "1px solid" });
-  t.is(a.border, "1px solid");
-});
+test('borders returns a border shorthand style', t => {
+  const a = borders({ border: '1px solid' })
+  t.is(a.border, '1px solid')
+})
 
-test("borders converts numbers to a border shorthand style", t => {
-  const a = borders({ border: 1 });
-  t.is(a.border, "1px solid");
-});
+test('borders converts numbers to a border shorthand style', t => {
+  const a = borders({ border: 1 })
+  t.is(a.border, '1px solid')
+})
 
-test("borders handles responsive styles", t => {
-  const a = borders({ border: [0, 1] });
-  t.is(a.border, 0);
-  t.is(a["@media screen and (min-width: 40em)"].border, "1px solid");
-});
+test('borders handles responsive styles', t => {
+  const a = borders({ border: [0, 1] })
+  t.is(a.border, 0)
+  t.is(a['@media screen and (min-width: 40em)'].border, '1px solid')
+})
 
-test("borders converts borderTop shorthand styles", t => {
-  const a = borders({ borderTop: "1px solid" });
-  t.is(a.borderTop, "1px solid");
-});
+test('borders converts borderTop shorthand styles', t => {
+  const a = borders({ borderTop: '1px solid' })
+  t.is(a.borderTop, '1px solid')
+})
 
-test("borders converts borderTop number shorthand styles", t => {
-  const a = borders({ borderTop: 1 });
-  t.is(a.borderTop, "1px solid");
-});
+test('borders converts borderTop number shorthand styles', t => {
+  const a = borders({ borderTop: 1 })
+  t.is(a.borderTop, '1px solid')
+})
 
-test("borders converts borderRight shorthand styles", t => {
-  const a = borders({ borderRight: "1px solid" });
-  t.is(a.borderRight, "1px solid");
-});
+test('borders converts borderRight shorthand styles', t => {
+  const a = borders({ borderRight: '1px solid' })
+  t.is(a.borderRight, '1px solid')
+})
 
-test("borders converts borderRight number shorthand styles", t => {
-  const a = borders({ borderRight: 1 });
-  t.is(a.borderRight, "1px solid");
-});
+test('borders converts borderRight number shorthand styles', t => {
+  const a = borders({ borderRight: 1 })
+  t.is(a.borderRight, '1px solid')
+})
 
-test("borders converts borderBottom shorthand styles", t => {
-  const a = borders({ borderBottom: "1px solid" });
-  t.is(a.borderBottom, "1px solid");
-});
+test('borders converts borderBottom shorthand styles', t => {
+  const a = borders({ borderBottom: '1px solid' })
+  t.is(a.borderBottom, '1px solid')
+})
 
-test("borders converts borderBottom number shorthand styles", t => {
-  const a = borders({ borderBottom: 1 });
-  t.is(a.borderBottom, "1px solid");
-});
+test('borders converts borderBottom number shorthand styles', t => {
+  const a = borders({ borderBottom: 1 })
+  t.is(a.borderBottom, '1px solid')
+})
 
-test("borders converts borderLeft shorthand styles", t => {
-  const a = borders({ borderLeft: "1px solid" });
-  t.is(a.borderLeft, "1px solid");
-});
+test('borders converts borderLeft shorthand styles', t => {
+  const a = borders({ borderLeft: '1px solid' })
+  t.is(a.borderLeft, '1px solid')
+})
 
-test("borders converts borderLeft number shorthand styles", t => {
-  const a = borders({ borderLeft: 1 });
-  t.is(a.borderLeft, "1px solid");
-});
+test('borders converts borderLeft number shorthand styles', t => {
+  const a = borders({ borderLeft: 1 })
+  t.is(a.borderLeft, '1px solid')
+})
 
-test("borders combines multiple border styles", t => {
+test('borders combines multiple border styles', t => {
   const a = borders({
     borderTop: 1,
-    borderBottom: 2
-  });
-  t.is(a.borderTop, "1px solid");
-  t.is(a.borderBottom, "2px solid");
-});
+    borderBottom: 2,
+  })
+  t.is(a.borderTop, '1px solid')
+  t.is(a.borderBottom, '2px solid')
+})
 
-test("borders combines multiple responsive styles", t => {
+test('borders combines multiple responsive styles', t => {
   const a = borders({
-    borderTop: ["1px solid", "2px solid"],
-    borderBottom: ["none", "2px solid"]
-  });
+    borderTop: ['1px solid', '2px solid'],
+    borderBottom: ['none', '2px solid'],
+  })
   t.deepEqual(a, {
-    borderTop: "1px solid",
-    borderBottom: "none",
-    "@media screen and (min-width: 40em)": {
-      borderTop: "2px solid",
-      borderBottom: "2px solid"
-    }
-  });
-});
+    borderTop: '1px solid',
+    borderBottom: 'none',
+    '@media screen and (min-width: 40em)': {
+      borderTop: '2px solid',
+      borderBottom: '2px solid',
+    },
+  })
+})
 
-test("boxShadow returns box-shadow styles", t => {
-  const a = boxShadow({ boxShadow: "0 0 8px rgba(0, 0, 0, .125)" });
-  t.deepEqual(a, { boxShadow: "0 0 8px rgba(0, 0, 0, .125)" });
-});
+test('boxShadow returns box-shadow styles', t => {
+  const a = boxShadow({ boxShadow: '0 0 8px rgba(0, 0, 0, .125)' })
+  t.deepEqual(a, { boxShadow: '0 0 8px rgba(0, 0, 0, .125)' })
+})
 
-test("boxShadow returns theme value", t => {
+test('boxShadow returns theme value', t => {
   const a = boxShadow({
     theme: {
-      shadows: ["0 0 4px rgba(0, 0, 0, .125)", "0 0 8px rgba(0, 0, 0, .125)"]
+      shadows: ['0 0 4px rgba(0, 0, 0, .125)', '0 0 8px rgba(0, 0, 0, .125)'],
     },
-    boxShadow: 1
-  });
-  t.deepEqual(a, { boxShadow: "0 0 8px rgba(0, 0, 0, .125)" });
-});
+    boxShadow: 1,
+  })
+  t.deepEqual(a, { boxShadow: '0 0 8px rgba(0, 0, 0, .125)' })
+})
 
-test("opacity returns opacity styles", t => {
-  const a = opacity({ opacity: 0.5 });
-  t.deepEqual(a, { opacity: 0.5 });
-});
+test('opacity returns opacity styles', t => {
+  const a = opacity({ opacity: 0.5 })
+  t.deepEqual(a, { opacity: 0.5 })
+})
 
-test("background returns background", t => {
-  const a = background({ background: "tomato" });
-  t.is(a.background, "tomato");
-});
+test('background returns background', t => {
+  const a = background({ background: 'tomato' })
+  t.is(a.background, 'tomato')
+})
 
-test("backgroundImage returns backgroundImage", t => {
-  const a = backgroundImage({ backgroundImage: "url(kitten.png)" });
-  t.is(a.backgroundImage, "url(kitten.png)");
-});
+test('backgroundImage returns backgroundImage', t => {
+  const a = backgroundImage({ backgroundImage: 'url(kitten.png)' })
+  t.is(a.backgroundImage, 'url(kitten.png)')
+})
 
-test("backgroundSize returns backgroundSize", t => {
-  const a = backgroundSize({ backgroundSize: "cover" });
-  t.is(a.backgroundSize, "cover");
-});
+test('backgroundSize returns backgroundSize', t => {
+  const a = backgroundSize({ backgroundSize: 'cover' })
+  t.is(a.backgroundSize, 'cover')
+})
 
-test("backgroundPosition returns backgroundPosition", t => {
-  const a = backgroundPosition({ backgroundPosition: "center" });
-  t.is(a.backgroundPosition, "center");
-});
+test('backgroundPosition returns backgroundPosition', t => {
+  const a = backgroundPosition({ backgroundPosition: 'center' })
+  t.is(a.backgroundPosition, 'center')
+})
 
-test("backgroundRepeat returns backgroundRepeat", t => {
-  const a = backgroundRepeat({ backgroundRepeat: "repeat" });
-  t.is(a.backgroundRepeat, "repeat");
-});
+test('backgroundRepeat returns backgroundRepeat', t => {
+  const a = backgroundRepeat({ backgroundRepeat: 'repeat' })
+  t.is(a.backgroundRepeat, 'repeat')
+})
 
-test("position returns position", t => {
-  const a = position({ position: "absolute" });
-  t.is(a.position, "absolute");
-});
+test('position returns position', t => {
+  const a = position({ position: 'absolute' })
+  t.is(a.position, 'absolute')
+})
 
-test("zIndex returns zIndex", t => {
-  const a = zIndex({ zIndex: 2 });
-  t.is(a.zIndex, 2);
-});
+test('zIndex returns zIndex', t => {
+  const a = zIndex({ zIndex: 2 })
+  t.is(a.zIndex, 2)
+})
 
-test("top returns top", t => {
-  const a = top({ top: 2 });
-  t.is(a.top, "2px");
-});
+test('top returns top', t => {
+  const a = top({ top: 2 })
+  t.is(a.top, '2px')
+})
 
-test("right returns right", t => {
-  const a = right({ right: 2 });
-  t.is(a.right, "2px");
-});
+test('right returns right', t => {
+  const a = right({ right: 2 })
+  t.is(a.right, '2px')
+})
 
-test("bottom returns bottom", t => {
-  const a = bottom({ bottom: 2 });
-  t.is(a.bottom, "2px");
-});
+test('bottom returns bottom', t => {
+  const a = bottom({ bottom: 2 })
+  t.is(a.bottom, '2px')
+})
 
-test("left returns left", t => {
-  const a = left({ left: 2 });
-  t.is(a.left, "2px");
-});
+test('left returns left', t => {
+  const a = left({ left: 2 })
+  t.is(a.left, '2px')
+})
 
-test("responsive props can have falsey values", t => {
-  const dec = space({ m: [null, 1] });
+test('responsive props can have falsey values', t => {
+  const dec = space({ m: [null, 1] })
   t.deepEqual(dec, {
-    "@media screen and (min-width: 40em)": {
-      margin: "4px"
-    }
-  });
-});
+    '@media screen and (min-width: 40em)': {
+      margin: '4px',
+    },
+  })
+})
 
-test("textStyle returns a value from theme", t => {
+test('textStyle returns a value from theme', t => {
   const theme = {
     textStyles: {
       caps: {
-        fontSize: "12px",
-        textTransform: "uppercase",
-        letterSpacing: "0.2em"
-      }
-    }
-  };
-  const a = textStyle({ textStyle: "caps", theme });
-  t.deepEqual(a, theme.textStyles.caps);
-});
+        fontSize: '12px',
+        textTransform: 'uppercase',
+        letterSpacing: '0.2em',
+      },
+    },
+  }
+  const a = textStyle({ textStyle: 'caps', theme })
+  t.deepEqual(a, theme.textStyles.caps)
+})
 
-test("colorStyle returns a value from theme", t => {
+test('colorStyle returns a value from theme', t => {
   const theme = {
     colorStyles: {
       primary: {
-        color: "white",
-        backgroundColor: "tomato"
-      }
-    }
-  };
-  const a = colorStyle({ colors: "primary", theme });
-  t.deepEqual(a, theme.colorStyles.primary);
-});
+        color: 'white',
+        backgroundColor: 'tomato',
+      },
+    },
+  }
+  const a = colorStyle({ colors: 'primary', theme })
+  t.deepEqual(a, theme.colorStyles.primary)
+})
 
-test("buttonStyle returns a value from theme", t => {
+test('buttonStyle returns a value from theme', t => {
   const theme = {
     buttons: {
       primary: {
-        color: "white",
-        backgroundColor: "tomato",
-        "&:hover": {
-          backgroundColor: "black"
-        }
-      }
-    }
-  };
-  const a = buttonStyle({ variant: "primary", theme });
-  t.deepEqual(a, theme.buttons.primary);
-});
+        color: 'white',
+        backgroundColor: 'tomato',
+        '&:hover': {
+          backgroundColor: 'black',
+        },
+      },
+    },
+  }
+  const a = buttonStyle({ variant: 'primary', theme })
+  t.deepEqual(a, theme.buttons.primary)
+})
 
-test("variant returns a value from theme", t => {
+test('variant returns a value from theme', t => {
   const theme = {
     buttons: {
       primary: {
-        backgroundColor: "tomato"
-      }
-    }
-  };
-  const a = variant({ key: "buttons" })({ theme, variant: "primary" });
-  t.deepEqual(a, theme.buttons.primary);
-});
+        backgroundColor: 'tomato',
+      },
+    },
+  }
+  const a = variant({ key: 'buttons' })({ theme, variant: 'primary' })
+  t.deepEqual(a, theme.buttons.primary)
+})
 
-test("variant returns null", t => {
-  const theme = {};
-  const a = variant({ key: "buttons" })({ theme, variant: "primary" });
-  t.is(a, null);
-});
+test('variant returns null', t => {
+  const theme = {}
+  const a = variant({ key: 'buttons' })({ theme, variant: 'primary' })
+  t.is(a, null)
+})
 
-test("mixed returns a style object", t => {
-  const a = mixed({ backgroundColor: "tomato" });
-  t.deepEqual(a, { backgroundColor: "tomato" });
-});
+test('mixed returns a style object', t => {
+  const a = mixed({ backgroundColor: 'tomato' })
+  t.deepEqual(a, { backgroundColor: 'tomato' })
+})
 
-test("mixed returns prop-based styles", t => {
-  const a = mixed({ bg: "tomato" });
-  t.deepEqual(a, { backgroundColor: "tomato" });
-});
+test('mixed returns prop-based styles', t => {
+  const a = mixed({ bg: 'tomato' })
+  t.deepEqual(a, { backgroundColor: 'tomato' })
+})
 
-test("mixed returns theme-based styles", t => {
-  const a = mixed({ theme, bg: "blue" });
-  t.deepEqual(a, { backgroundColor: theme.colors.blue });
-});
+test('mixed returns theme-based styles', t => {
+  const a = mixed({ theme, bg: 'blue' })
+  t.deepEqual(a, { backgroundColor: theme.colors.blue })
+})
 
 Object.keys(styles).forEach(key => {
   test(`${key}.propTypes is an object`, t => {
-    const fn = system[key];
-    if (typeof fn !== "function") return t.pass();
-    t.is(typeof fn.propTypes, "object");
+    const fn = system[key]
+    if (typeof fn !== 'function') return t.pass()
+    t.is(typeof fn.propTypes, 'object')
     Object.keys(fn.propTypes).forEach(prop => {
-      t.is(typeof fn.propTypes[prop], "function");
-    });
-  });
-});
+      t.is(typeof fn.propTypes[prop], 'function')
+    })
+  })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,24 +1,21 @@
-import test from 'ava'
-import * as system from '../src'
+import test from "ava";
+import * as system from "../src";
 import {
   styles,
   space,
   width,
   fontSize,
   color,
-
   style,
   themeGet,
   util,
   variant,
   mixed,
-
   textAlign,
   fontFamily,
   lineHeight,
   fontWeight,
   letterSpacing,
-
   display,
   maxWidth,
   minWidth,
@@ -28,7 +25,6 @@ import {
   size,
   ratio,
   verticalAlign,
-
   alignItems,
   alignContent,
   justifyContent,
@@ -38,7 +34,6 @@ import {
   justifySelf,
   alignSelf,
   order,
-
   gridGap,
   gridColumnGap,
   gridRowGap,
@@ -49,1236 +44,1217 @@ import {
   gridAutoRows,
   gridTemplateColumns,
   gridTemplateRows,
-
   borderRadius,
   borderColor,
   borders,
   boxShadow,
   opacity,
-
   background,
   backgroundImage,
   backgroundSize,
   backgroundPosition,
   backgroundRepeat,
-
   position,
   zIndex,
   top,
   right,
   bottom,
   left,
-
   hover,
   focus,
   active,
   disabled,
-
   textStyle,
   colorStyle,
-  buttonStyle,
-} from '../src'
+  buttonStyle
+} from "../src";
 
 const theme = {
-  breakpoints: [32, 48, 64].map(n => n + 'em'),
+  breakpoints: [32, 48, 64].map(n => n + "em"),
   space: [0, 6, 12, 18, 24],
   fontSizes: [12, 16, 18, 24, 36, 72],
-  radii: [ 2, 4 ],
+  radii: [2, 4],
   colors: {
-    blue: '#07c',
-    green: '#1c0',
-    gray: ['#ccc', '#555']
+    blue: "#07c",
+    green: "#1c0",
+    gray: ["#ccc", "#555"]
   }
-}
+};
 
 // aliases
-theme.space.big = 64
-theme.fontSizes.big = 128
+theme.space.big = 64;
+theme.fontSizes.big = 128;
 
-test('exports space, width, and fontSize', t => {
-  t.is(typeof space, 'function')
-  t.is(typeof width, 'function')
-  t.is(typeof fontSize, 'function')
-})
+test("exports space, width, and fontSize", t => {
+  t.is(typeof space, "function");
+  t.is(typeof width, "function");
+  t.is(typeof fontSize, "function");
+});
 
-test('themeGet gets theme values', t => {
-  const a = themeGet('colors.gray.0')({ theme })
-  t.is(a, theme.colors.gray[0])
-})
+test("themeGet gets theme values", t => {
+  const a = themeGet("colors.gray.0")({ theme });
+  t.is(a, theme.colors.gray[0]);
+});
 
-test('themeGet returns a fallback', t => {
-  const a = themeGet('colors.blue', 'tomato')({ theme: {} })
-  t.is(a, 'tomato')
-})
+test("themeGet returns a fallback", t => {
+  const a = themeGet("colors.blue", "tomato")({ theme: {} });
+  t.is(a, "tomato");
+});
 
-test.skip('themeGet returns declared 0 rather than undefined', t => {
-  const a = themeGet('space.0')({ theme })
-  t.is(a, 0)
-})
+test.skip("themeGet returns declared 0 rather than undefined", t => {
+  const a = themeGet("space.0")({ theme });
+  t.is(a, 0);
+});
 
 // util
-test('util.is checks for non null values', t => {
-  const a = util.is(null)
-  const b = util.is()
-  const c = util.is(0)
-  const d = util.is('')
-  const e = util.is(false)
-  const f = util.is([])
-  t.false(a)
-  t.false(b)
-  t.true(c)
-  t.true(d)
-  t.true(e)
-  t.true(f)
-})
+test("util.is checks for non null values", t => {
+  const a = util.is(null);
+  const b = util.is();
+  const c = util.is(0);
+  const d = util.is("");
+  const e = util.is(false);
+  const f = util.is([]);
+  t.false(a);
+  t.false(b);
+  t.true(c);
+  t.true(d);
+  t.true(e);
+  t.true(f);
+});
 
-test('util.px adds px unit to numbers', t => {
-  const a = util.px(1)
-  const b = util.px('2em')
-  t.is(a, '1px')
-  t.is(b, '2em')
-})
+test("util.px adds px unit to numbers", t => {
+  const a = util.px(1);
+  const b = util.px("2em");
+  t.is(a, "1px");
+  t.is(b, "2em");
+});
 
-test('util.num checks for a number', t => {
-  const a = util.num(1)
-  const b = util.num(0)
-  const c = util.num('1')
-  const d = util.num(null)
-  t.true(a)
-  t.true(b)
-  t.false(c)
-  t.false(d)
-})
+test("util.num checks for a number", t => {
+  const a = util.num(1);
+  const b = util.num(0);
+  const c = util.num("1");
+  const d = util.num(null);
+  t.true(a);
+  t.true(b);
+  t.false(c);
+  t.false(d);
+});
 
-test('util.merge reduces objects', t => {
+test("util.merge reduces objects", t => {
   const a = [
     {
-      a: 'hello',
+      a: "hello",
       b: {
-        beep: 'boop'
+        beep: "boop"
       }
     },
     {
       b: {
-        hello: 'hi'
+        hello: "hi"
       }
     }
-  ].reduce(util.merge, {})
+  ].reduce(util.merge, {});
   t.deepEqual(a, {
-    a: 'hello',
+    a: "hello",
     b: {
-      beep: 'boop',
-      hello: 'hi'
+      beep: "boop",
+      hello: "hi"
     }
-  })
-})
+  });
+});
 
-test('util.merge merges objects', t => {
-  const a = util.merge({
-    a: 'hello',
+test("util.merge merges objects", t => {
+  const a = util.merge(
+    {
+      a: "hello",
+      b: {
+        beep: "boop"
+      },
+      c: {
+        d: 2,
+        e: "f"
+      }
+    },
+    {
+      b: {
+        hello: "hi"
+      },
+      c: {
+        g: 3
+      }
+    }
+  );
+  t.deepEqual(a, {
+    a: "hello",
     b: {
-      beep: 'boop'
+      beep: "boop",
+      hello: "hi"
     },
     c: {
       d: 2,
-      e: 'f'
-    }
-  }, {
-    b: {
-      hello: 'hi'
-    },
-    c: {
+      e: "f",
       g: 3
     }
-  })
-  t.deepEqual(a, {
-    a: 'hello',
-    b: {
-      beep: 'boop',
-      hello: 'hi'
-    },
-    c: {
-      d: 2,
-      e: 'f',
-      g: 3
-    }
-  })
-})
+  });
+});
 
-test('util.merge doesn’t throw with null values', t => {
+test("util.merge doesn’t throw with null values", t => {
   t.notThrows(() => {
-    util.merge(null, null)
-  })
-})
+    util.merge(null, null);
+  });
+});
 
-test('util.compose combines style functions', t => {
-  const combo = util.compose(display, width)
-  const a = combo({ display: 'inline-block', width: 1/2 })
+test("util.compose combines style functions", t => {
+  const combo = util.compose(
+    display,
+    width
+  );
+  const a = combo({ display: "inline-block", width: 1 / 2 });
   t.deepEqual(a, {
-    display: 'inline-block',
-    width: '50%'
-  })
-})
+    display: "inline-block",
+    width: "50%"
+  });
+});
 
-test('util.get returns nested values', t => {
-  const value = util.get({ colors: { blue: '#07c' } }, 'colors.blue')
-  t.is(value, '#07c')
-})
+test("util.get returns nested values", t => {
+  const value = util.get({ colors: { blue: "#07c" } }, "colors.blue");
+  t.is(value, "#07c");
+});
 
 // space
-test('space returns margin declarations', t => {
-  const dec = space({m: 1})
-  t.deepEqual(dec, {margin: '4px'})
-})
+test("space returns margin declarations", t => {
+  const dec = space({ m: 1 });
+  t.deepEqual(dec, { margin: "4px" });
+});
 
-test('space returns non-scalar margins', t => {
-  const a = space({m: 24})
-  const b = space({m: 'auto'})
-  t.deepEqual(a, {margin: '24px'})
-  t.deepEqual(b, {margin: 'auto'})
-})
+test("space returns non-scalar margins", t => {
+  const a = space({ m: 24 });
+  const b = space({ m: "auto" });
+  t.deepEqual(a, { margin: "24px" });
+  t.deepEqual(b, { margin: "auto" });
+});
 
-test('space returns keyed values', t => {
+test("space returns keyed values", t => {
   const a = space({
-    theme,
-    m: 'big'
-  })
-  t.is(a.margin, theme.space.big + 'px')
-})
-
-test('space returns negative margins', t => {
-  const a = space({m: -1})
-  const b = space({m: -24})
-  t.deepEqual(a, {margin: '-4px'})
-  t.deepEqual(b, {margin: '-24px'})
-})
-
-test('space returns directional margins', t => {
-  const top = space({mt: 1})
-  const r = space({mr: 2})
-  const b = space({mb: 3})
-  const l = space({ml: 4})
-  const x = space({mx: 1})
-  const y = space({my: 2})
-  t.deepEqual(top, {'marginTop': '4px'})
-  t.deepEqual(r, {'marginRight': '8px'})
-  t.deepEqual(b, {'marginBottom': '16px'})
-  t.deepEqual(l, {'marginLeft': '32px'})
-  t.deepEqual(x, {'marginLeft': '4px', 'marginRight': '4px'})
-  t.deepEqual(y, {'marginTop': '8px', 'marginBottom': '8px'})
-})
-
-test('space returns responsive margins', t => {
-  const a = space({m: [0, 1]})
-  t.deepEqual(a, {
-    margin: '0px',
-    '@media screen and (min-width: 40em)': {
-      margin: '4px',
+    theme: {
+      space: {
+        nested: {
+          big: theme.space.big
+        }
+      }
     },
-  })
-})
+    m: "nested.big"
+  });
+  t.is(a.margin, theme.space.big + "px");
+});
 
-test('space returns responsive directional margins', t => {
-  const a = space({mt: [0, 1], mb: [2, 3]})
+test("space returns negative margins", t => {
+  const a = space({ m: -1 });
+  const b = space({ m: -24 });
+  t.deepEqual(a, { margin: "-4px" });
+  t.deepEqual(b, { margin: "-24px" });
+});
+
+test("space returns directional margins", t => {
+  const top = space({ mt: 1 });
+  const r = space({ mr: 2 });
+  const b = space({ mb: 3 });
+  const l = space({ ml: 4 });
+  const x = space({ mx: 1 });
+  const y = space({ my: 2 });
+  t.deepEqual(top, { marginTop: "4px" });
+  t.deepEqual(r, { marginRight: "8px" });
+  t.deepEqual(b, { marginBottom: "16px" });
+  t.deepEqual(l, { marginLeft: "32px" });
+  t.deepEqual(x, { marginLeft: "4px", marginRight: "4px" });
+  t.deepEqual(y, { marginTop: "8px", marginBottom: "8px" });
+});
+
+test("space returns responsive margins", t => {
+  const a = space({ m: [0, 1] });
   t.deepEqual(a, {
-    marginBottom: '8px',
-    marginTop: '0px',
-    '@media screen and (min-width: 40em)': {
-      marginBottom: '16px',
-      marginTop: '4px',
-    },
-  })
-})
+    margin: "0px",
+    "@media screen and (min-width: 40em)": {
+      margin: "4px"
+    }
+  });
+});
 
-test('space sorts responsive directional margins', t => {
+test("space returns responsive directional margins", t => {
+  const a = space({ mt: [0, 1], mb: [2, 3] });
+  t.deepEqual(a, {
+    marginBottom: "8px",
+    marginTop: "0px",
+    "@media screen and (min-width: 40em)": {
+      marginBottom: "16px",
+      marginTop: "4px"
+    }
+  });
+});
+
+test("space sorts responsive directional margins", t => {
   const a = space({
     mb: 2,
     m: [0, 1]
-  })
-  const keys = Object.keys(a)
+  });
+  const keys = Object.keys(a);
   t.deepEqual(keys, [
-    'margin',
-    '@media screen and (min-width: 40em)',
-    'marginBottom'
-  ])
-})
+    "margin",
+    "@media screen and (min-width: 40em)",
+    "marginBottom"
+  ]);
+});
 
-test('space returns padding declarations', t => {
-  const dec = space({p: 1})
-  t.deepEqual(dec, {padding: '4px'})
-})
+test("space returns padding declarations", t => {
+  const dec = space({ p: 1 });
+  t.deepEqual(dec, { padding: "4px" });
+});
 
-test('space returns non-scalar paddings', t => {
-  const a = space({p: 24})
-  const b = space({p: 'auto'})
-  t.deepEqual(a, {padding: '24px'})
-  t.deepEqual(b, {padding: 'auto'})
-})
+test("space returns non-scalar paddings", t => {
+  const a = space({ p: 24 });
+  const b = space({ p: "auto" });
+  t.deepEqual(a, { padding: "24px" });
+  t.deepEqual(b, { padding: "auto" });
+});
 
-test('space returns directional paddings', t => {
-  const top = space({pt: 1})
-  const r = space({pr: 2})
-  const b = space({pb: 3})
-  const l = space({pl: 4})
-  const x = space({px: 1})
-  const y = space({py: 2})
-  t.deepEqual(top, {'paddingTop': '4px'})
-  t.deepEqual(r, {'paddingRight': '8px'})
-  t.deepEqual(b, {'paddingBottom': '16px'})
-  t.deepEqual(l, {'paddingLeft': '32px'})
-  t.deepEqual(x, {'paddingLeft': '4px', 'paddingRight': '4px'})
-  t.deepEqual(y, {'paddingTop': '8px', 'paddingBottom': '8px'})
-})
+test("space returns directional paddings", t => {
+  const top = space({ pt: 1 });
+  const r = space({ pr: 2 });
+  const b = space({ pb: 3 });
+  const l = space({ pl: 4 });
+  const x = space({ px: 1 });
+  const y = space({ py: 2 });
+  t.deepEqual(top, { paddingTop: "4px" });
+  t.deepEqual(r, { paddingRight: "8px" });
+  t.deepEqual(b, { paddingBottom: "16px" });
+  t.deepEqual(l, { paddingLeft: "32px" });
+  t.deepEqual(x, { paddingLeft: "4px", paddingRight: "4px" });
+  t.deepEqual(y, { paddingTop: "8px", paddingBottom: "8px" });
+});
 
-test('space returns responsive paddings', t => {
-  const a = space({p: [0, 1]})
+test("space returns responsive paddings", t => {
+  const a = space({ p: [0, 1] });
   t.deepEqual(a, {
-    padding: '0px',
-    '@media screen and (min-width: 40em)': {
-      padding: '4px',
-    },
-  })
-})
+    padding: "0px",
+    "@media screen and (min-width: 40em)": {
+      padding: "4px"
+    }
+  });
+});
 
-test('space returns responsive directional paddings', t => {
-  const a = space({pt: [0, 1], pb: [2, 3]})
+test("space returns responsive directional paddings", t => {
+  const a = space({ pt: [0, 1], pb: [2, 3] });
   t.deepEqual(a, {
-    paddingBottom: '8px',
-    paddingTop: '0px',
-    '@media screen and (min-width: 40em)': {
-      paddingBottom: '16px',
-      paddingTop: '4px',
-    },
-  })
-})
+    paddingBottom: "8px",
+    paddingTop: "0px",
+    "@media screen and (min-width: 40em)": {
+      paddingBottom: "16px",
+      paddingTop: "4px"
+    }
+  });
+});
 
-test('space can be configured with a theme', t => {
-  const a = space({theme, m: 1})
-  const b = space({theme, m: 2})
-  const c = space({theme, m: 3})
-  const d = space({theme, m: 4})
-  t.deepEqual(a, {margin: '6px'})
-  t.deepEqual(b, {margin: '12px'})
-  t.deepEqual(c, {margin: '18px'})
-  t.deepEqual(d, {margin: '24px'})
-})
+test("space can be configured with a theme", t => {
+  const a = space({ theme, m: 1 });
+  const b = space({ theme, m: 2 });
+  const c = space({ theme, m: 3 });
+  const d = space({ theme, m: 4 });
+  t.deepEqual(a, { margin: "6px" });
+  t.deepEqual(b, { margin: "12px" });
+  t.deepEqual(c, { margin: "18px" });
+  t.deepEqual(d, { margin: "24px" });
+});
 
-test('space can accept string values', t => {
-  const a = space({ theme: { space: ['1em', '2em'] }, m: 1 })
-  t.deepEqual(a, {margin: '2em'})
-})
+test("space can accept string values", t => {
+  const a = space({ theme: { space: ["1em", "2em"] }, m: 1 });
+  t.deepEqual(a, { margin: "2em" });
+});
 
-test('space can accept string values with negative', t => {
-  const a = space({ theme: { space: ['1em', '2em'] }, m: -1 })
-  t.deepEqual(a, {margin: '-2em'})
-})
+test("space can accept string values with negative", t => {
+  const a = space({ theme: { space: ["1em", "2em"] }, m: -1 });
+  t.deepEqual(a, { margin: "-2em" });
+});
 
-test('space handles null values in arrays', t => {
+test("space handles null values in arrays", t => {
   const a = space({
-    m: [ 0, null, 2 ],
+    m: [0, null, 2],
     theme: {
-      space: [ 0, 4, 8, 16 ]
+      space: [0, 4, 8, 16]
     }
-  })
+  });
   t.deepEqual(a, {
-    margin: '0px',
-    '@media screen and (min-width: 52em)': {
-      margin: '8px'
+    margin: "0px",
+    "@media screen and (min-width: 52em)": {
+      margin: "8px"
     }
-  })
-})
+  });
+});
 
-test('space can handle alias values', t => {
+test("space can handle alias values", t => {
   const a = space({
-    m: 'large',
+    m: "large",
     theme: {
       space: {
         large: 12
       }
     }
-  })
-  t.deepEqual(a, {margin: '12px'})
-})
+  });
+  t.deepEqual(a, { margin: "12px" });
+});
 
 // width
-test('width returns percentage widths', t => {
-  const a = width({width: 1 / 2})
-  t.deepEqual(a, {width: '50%'})
-})
+test("width returns percentage widths", t => {
+  const a = width({ width: 1 / 2 });
+  t.deepEqual(a, { width: "50%" });
+});
 
-test('width returns pixel values', t => {
-  const a = width({width: 256})
-  t.deepEqual(a, {width: '256px'})
-})
+test("width returns pixel values", t => {
+  const a = width({ width: 256 });
+  t.deepEqual(a, { width: "256px" });
+});
 
-test('width returns string values', t => {
-  const a = width({width: 'auto'})
-  t.deepEqual(a, {width: 'auto'})
-})
+test("width returns string values", t => {
+  const a = width({ width: "auto" });
+  t.deepEqual(a, { width: "auto" });
+});
 
-test('width returns responsive values', t => {
-  const a = width({width: [1, 1 / 2]})
+test("width returns responsive values", t => {
+  const a = width({ width: [1, 1 / 2] });
   t.deepEqual(a, {
-    width: '100%',
-    '@media screen and (min-width: 40em)': {width: '50%'},
-  })
-})
+    width: "100%",
+    "@media screen and (min-width: 40em)": { width: "50%" }
+  });
+});
 
-test('width returns responsive pixel values', t => {
-  const a = width({width: [128, 256]})
+test("width returns responsive pixel values", t => {
+  const a = width({ width: [128, 256] });
   t.deepEqual(a, {
-    width: '128px',
-    '@media screen and (min-width: 40em)': {width: '256px'},
-  })
-})
+    width: "128px",
+    "@media screen and (min-width: 40em)": { width: "256px" }
+  });
+});
 
-test('width returns 0 value', t => {
-  const a = width({width: 0})
-  t.deepEqual(a, {width: '0%'})
-})
+test("width returns 0 value", t => {
+  const a = width({ width: 0 });
+  t.deepEqual(a, { width: "0%" });
+});
 
-test('width returns null ', t => {
-  const a = width({})
-  t.is(a, null)
-})
+test("width returns null ", t => {
+  const a = width({});
+  t.is(a, null);
+});
 
 // fontSize
-test('fontSize returns scale values', t => {
-  const a = fontSize({ fontSize: 0, theme: {} })
-  const b = fontSize({ fontSize: 1, theme: {} })
-  const c = fontSize({ fontSize: 2 })
-  t.deepEqual(a, {'fontSize': '12px'})
-  t.deepEqual(b, {'fontSize': '14px'})
-  t.deepEqual(c, {'fontSize': '16px'})
-})
+test("fontSize returns scale values", t => {
+  const a = fontSize({ fontSize: 0, theme: {} });
+  const b = fontSize({ fontSize: 1, theme: {} });
+  const c = fontSize({ fontSize: 2 });
+  t.deepEqual(a, { fontSize: "12px" });
+  t.deepEqual(b, { fontSize: "14px" });
+  t.deepEqual(c, { fontSize: "16px" });
+});
 
-test('fontSize returns keyed values', t => {
+test("fontSize returns keyed values", t => {
   const a = fontSize({
     theme,
-    fontSize: 'big'
-  })
-  t.is(a.fontSize, theme.fontSizes.big + 'px')
-})
+    fontSize: "big"
+  });
+  t.is(a.fontSize, theme.fontSizes.big + "px");
+});
 
-test('fontSize returns pixel values', t => {
-  const a = fontSize({fontSize: 24})
-  t.deepEqual(a, {'fontSize': '24px'})
-})
+test("fontSize returns pixel values", t => {
+  const a = fontSize({ fontSize: 24 });
+  t.deepEqual(a, { fontSize: "24px" });
+});
 
-test('fontSize returns string values', t => {
-  const a = fontSize({fontSize: '2em'})
-  t.deepEqual(a, {'fontSize': '2em'})
-})
+test("fontSize returns string values", t => {
+  const a = fontSize({ fontSize: "2em" });
+  t.deepEqual(a, { fontSize: "2em" });
+});
 
-test('fontSize returns responsive values', t => {
-  const a = fontSize({fontSize: [1, 2]})
+test("fontSize returns responsive values", t => {
+  const a = fontSize({ fontSize: [1, 2] });
   t.deepEqual(a, {
-    fontSize: '14px',
-    '@media screen and (min-width: 40em)': {
-      fontSize: '16px',
-    },
-  })
-})
+    fontSize: "14px",
+    "@media screen and (min-width: 40em)": {
+      fontSize: "16px"
+    }
+  });
+});
 
-test('fontSize can be configured with a theme', t => {
-  const a = fontSize({theme, fontSize: 0})
-  const b = fontSize({theme, fontSize: 1})
-  const c = fontSize({theme, fontSize: 2})
-  const d = fontSize({theme, fontSize: 3})
-  const e = fontSize({theme, fontSize: 4})
-  const f = fontSize({theme, fontSize: 5})
-  t.deepEqual(a, {'fontSize': '12px'})
-  t.deepEqual(b, {'fontSize': '16px'})
-  t.deepEqual(c, {'fontSize': '18px'})
-  t.deepEqual(d, {'fontSize': '24px'})
-  t.deepEqual(e, {'fontSize': '36px'})
-  t.deepEqual(f, {'fontSize': '72px'})
-})
+test("fontSize can be configured with a theme", t => {
+  const a = fontSize({ theme, fontSize: 0 });
+  const b = fontSize({ theme, fontSize: 1 });
+  const c = fontSize({ theme, fontSize: 2 });
+  const d = fontSize({ theme, fontSize: 3 });
+  const e = fontSize({ theme, fontSize: 4 });
+  const f = fontSize({ theme, fontSize: 5 });
+  t.deepEqual(a, { fontSize: "12px" });
+  t.deepEqual(b, { fontSize: "16px" });
+  t.deepEqual(c, { fontSize: "18px" });
+  t.deepEqual(d, { fontSize: "24px" });
+  t.deepEqual(e, { fontSize: "36px" });
+  t.deepEqual(f, { fontSize: "72px" });
+});
 
-test('fontSize returns null', t => {
-  const a = fontSize({})
-  t.is(a, null)
-})
+test("fontSize returns null", t => {
+  const a = fontSize({});
+  t.is(a, null);
+});
 
 // color
-test('color returns color and backgroundColor styles', t => {
-  const a = color({ color: 'tomato' })
-  const b = color({ bg: 'tomato' })
-  t.deepEqual(a, { color: 'tomato' })
-  t.deepEqual(b, { backgroundColor: 'tomato' })
-})
+test("color returns color and backgroundColor styles", t => {
+  const a = color({ color: "tomato" });
+  const b = color({ bg: "tomato" });
+  t.deepEqual(a, { color: "tomato" });
+  t.deepEqual(b, { backgroundColor: "tomato" });
+});
 
-test('color returns theme.colors values', t => {
-  const a = color({ theme, color: 'blue' })
-  const b = color({ theme, bg: 'green' })
-  t.deepEqual(a, { color: theme.colors.blue })
-  t.deepEqual(b, { backgroundColor: theme.colors.green })
-})
+test("color returns theme.colors values", t => {
+  const a = color({ theme, color: "blue" });
+  const b = color({ theme, bg: "green" });
+  t.deepEqual(a, { color: theme.colors.blue });
+  t.deepEqual(b, { backgroundColor: theme.colors.green });
+});
 
-test('color returns responsive values', t => {
-  const a = color({ theme, color: [ 'blue', 'green' ] })
+test("color returns responsive values", t => {
+  const a = color({ theme, color: ["blue", "green"] });
   t.deepEqual(a, {
     color: theme.colors.blue,
-    '@media screen and (min-width: 32em)': {
+    "@media screen and (min-width: 32em)": {
       color: theme.colors.green
     }
-  })
-})
+  });
+});
 
-test('color works with array theme.colors', t => {
+test("color works with array theme.colors", t => {
   const a = color({
     theme: {
-      colors: [ 'tomato', 'plum' ]
+      colors: ["tomato", "plum"]
     },
     color: 0
-  })
-  t.is(a.color, 'tomato')
-})
+  });
+  t.is(a.color, "tomato");
+});
 
-test('color keys support dot notation', t => {
+test("color keys support dot notation", t => {
   const a = color({
     theme: {
       colors: {
-        gray: [
-          '#333',
-          '#666',
-          '#999',
-        ]
+        gray: ["#333", "#666", "#999"]
       }
     },
-    color: 'gray.2'
-  })
-  t.is(a.color, '#999')
-})
+    color: "gray.2"
+  });
+  t.is(a.color, "#999");
+});
 
 // style
-test('style returns a function', t => {
+test("style returns a function", t => {
   const sx = style({
-    prop: 'color',
-    key: 'colors'
-  })
-  t.is(typeof sx, 'function')
-})
+    prop: "color",
+    key: "colors"
+  });
+  t.is(typeof sx, "function");
+});
 
-test('style function returns a style object', t => {
+test("style function returns a style object", t => {
   const a = style({
-    prop: 'color',
-    key: 'colors'
-  })({ color: 'tomato' })
-  t.is(typeof a, 'object')
-  t.deepEqual(a, { color: 'tomato' })
-})
+    prop: "color",
+    key: "colors"
+  })({ color: "tomato" });
+  t.is(typeof a, "object");
+  t.deepEqual(a, { color: "tomato" });
+});
 
-test('style function returns null', t => {
+test("style function returns null", t => {
   const sx = style({
-    prop: 'color'
-  })
-  const a = sx({})
-  t.is(a, null)
-})
+    prop: "color"
+  });
+  const a = sx({});
+  t.is(a, null);
+});
 
-test('style function returns scale values', t => {
+test("style function returns scale values", t => {
   const sx = style({
-    key: 'colors',
-    prop: 'color'
-  })
+    key: "colors",
+    prop: "color"
+  });
   const a = sx({
-    color: 'blue',
+    color: "blue",
     theme: {
       colors: {
-        blue: '#07c'
+        blue: "#07c"
       }
     }
-  })
-  t.is(a.color, '#07c')
-})
+  });
+  t.is(a.color, "#07c");
+});
 
-test('style function returns pixels for number values', t => {
+test("style function returns pixels for number values", t => {
   const sx = style({
-    prop: 'borderRadius',
+    prop: "borderRadius",
     transformValue: util.px
-  })
+  });
   const a = sx({
     borderRadius: 4,
     theme: {}
-  })
-  t.is(a.borderRadius, '4px')
-})
+  });
+  t.is(a.borderRadius, "4px");
+});
 
-test('style function returns unitless number values', t => {
+test("style function returns unitless number values", t => {
   const sx = style({
-    prop: 'borderRadius'
-  })
+    prop: "borderRadius"
+  });
   const a = sx({
     borderRadius: 4,
     theme: {}
-  })
-  t.is(a.borderRadius, 4)
-})
+  });
+  t.is(a.borderRadius, 4);
+});
 
-test('style function accepts a transformValue option', t => {
+test("style function accepts a transformValue option", t => {
   const sx = style({
-    prop: 'width',
-    transformValue: n => !util.num(n) || n > 1 ? util.px(n) : (n * 100) + '%'
-  })
-  const a = sx({ width: 1/2 })
-  const b = sx({ width: 24 })
-  t.is(a.width, '50%')
-  t.is(b.width, '24px')
-})
+    prop: "width",
+    transformValue: n => (!util.num(n) || n > 1 ? util.px(n) : n * 100 + "%")
+  });
+  const a = sx({ width: 1 / 2 });
+  const b = sx({ width: 24 });
+  t.is(a.width, "50%");
+  t.is(b.width, "24px");
+});
 
-test('style allows property aliases', t => {
+test("style allows property aliases", t => {
   const direction = style({
-    cssProperty: 'flex-direction',
-    prop: 'direction'
-  })
-  const a = direction({ direction: 'column' })
+    cssProperty: "flex-direction",
+    prop: "direction"
+  });
+  const a = direction({ direction: "column" });
   t.deepEqual(a, {
-    'flex-direction': 'column'
-  })
-})
+    "flex-direction": "column"
+  });
+});
 
-test('style allows array values', t => {
+test("style allows array values", t => {
   const direction = style({
-    cssProperty: 'flex-direction',
-    prop: 'direction'
-  })
-  const a = direction({ direction: [ 'column', null, 'row' ] })
+    cssProperty: "flex-direction",
+    prop: "direction"
+  });
+  const a = direction({ direction: ["column", null, "row"] });
   t.deepEqual(a, {
-    'flex-direction': 'column',
-    '@media screen and (min-width: 52em)': {
-      'flex-direction': 'row',
+    "flex-direction": "column",
+    "@media screen and (min-width: 52em)": {
+      "flex-direction": "row"
     }
-  })
-})
+  });
+});
 
-test('style returns pixel values for number arrays', t => {
+test("style returns pixel values for number arrays", t => {
   const radius = style({
-    cssProperty: 'borderRadius',
-    prop: 'radius',
+    cssProperty: "borderRadius",
+    prop: "radius",
     transformValue: util.px
-  })
-  const a = radius({ radius: [ 4, 5, 6 ] })
+  });
+  const a = radius({ radius: [4, 5, 6] });
   t.deepEqual(a, {
-    borderRadius: '4px',
-    '@media screen and (min-width: 40em)': {
-      borderRadius: '5px'
+    borderRadius: "4px",
+    "@media screen and (min-width: 40em)": {
+      borderRadius: "5px"
     },
-    '@media screen and (min-width: 52em)': {
-      borderRadius: '6px'
+    "@media screen and (min-width: 52em)": {
+      borderRadius: "6px"
     }
-  })
-})
+  });
+});
 
-test('style returns a theme value', t => {
+test("style returns a theme value", t => {
   const sx = style({
-    prop: 'borderColor',
-    key: 'colors',
-  })
+    prop: "borderColor",
+    key: "colors"
+  });
   const a = sx({
     theme,
-    borderColor: [
-      'blue',
-      'green'
-    ]
-  })
+    borderColor: ["blue", "green"]
+  });
   t.deepEqual(a, {
     borderColor: theme.colors.blue,
-    '@media screen and (min-width: 32em)': {
+    "@media screen and (min-width: 32em)": {
       borderColor: theme.colors.green
     }
-  })
-})
+  });
+});
 
-test('style returns a theme number value in px', t => {
+test("style returns a theme number value in px", t => {
   const sx = style({
-    prop: 'borderRadius',
-    key: 'radii',
+    prop: "borderRadius",
+    key: "radii",
     transformValue: util.px
-  })
+  });
   const a = sx({
     theme,
-    borderRadius: [ 0, 1 ]
-  })
+    borderRadius: [0, 1]
+  });
   t.deepEqual(a, {
-    borderRadius: theme.radii[0] + 'px',
-    '@media screen and (min-width: 32em)': {
-      borderRadius: theme.radii[1] + 'px'
+    borderRadius: theme.radii[0] + "px",
+    "@media screen and (min-width: 32em)": {
+      borderRadius: theme.radii[1] + "px"
     }
-  })
-})
+  });
+});
 
 // theme
-test('breakpoints can be configured with a theme', t => {
-  const a = space({theme, m: [1, 2, 3, 4]})
-  const [, b, c, d] = Object.keys(a)
-  t.is(b, '@media screen and (min-width: 32em)')
-  t.is(c, '@media screen and (min-width: 48em)')
-  t.is(d, '@media screen and (min-width: 64em)')
-})
+test("breakpoints can be configured with a theme", t => {
+  const a = space({ theme, m: [1, 2, 3, 4] });
+  const [, b, c, d] = Object.keys(a);
+  t.is(b, "@media screen and (min-width: 32em)");
+  t.is(c, "@media screen and (min-width: 48em)");
+  t.is(d, "@media screen and (min-width: 64em)");
+});
 
 // textAlign
-test('textAlign returns text-align', t => {
-  const a = textAlign({ textAlign: 'center' })
-  t.deepEqual(a, { textAlign: 'center' })
-})
+test("textAlign returns text-align", t => {
+  const a = textAlign({ textAlign: "center" });
+  t.deepEqual(a, { textAlign: "center" });
+});
 
-test('textAlign returns responsive text-align', t => {
-  const a = textAlign({ textAlign: [ 'center', 'left' ] })
+test("textAlign returns responsive text-align", t => {
+  const a = textAlign({ textAlign: ["center", "left"] });
   t.deepEqual(a, {
-    textAlign: 'center',
-    '@media screen and (min-width: 40em)': {
-      textAlign: 'left',
+    textAlign: "center",
+    "@media screen and (min-width: 40em)": {
+      textAlign: "left"
     }
-  })
-})
+  });
+});
 
-test('fontFamily returns font-family', t => {
-  const a = fontFamily({ fontFamily: 'system-ui' })
-  t.is(a.fontFamily, 'system-ui')
-})
+test("fontFamily returns font-family", t => {
+  const a = fontFamily({ fontFamily: "system-ui" });
+  t.is(a.fontFamily, "system-ui");
+});
 
 // lineHeight
-test('lineHeight returns line-height', t => {
-  const a = lineHeight({ lineHeight: 1.23 })
-  t.deepEqual(a, { lineHeight: 1.23 })
-})
+test("lineHeight returns line-height", t => {
+  const a = lineHeight({ lineHeight: 1.23 });
+  t.deepEqual(a, { lineHeight: 1.23 });
+});
 
-test('lineHeight returns a scalar style', t => {
+test("lineHeight returns a scalar style", t => {
   const a = lineHeight({
     theme: {
-      lineHeights: [
-        1, 2, 3
-      ]
+      lineHeights: [1, 2, 3]
     },
     lineHeight: 1
-  })
+  });
 
-  t.deepEqual(a, { lineHeight: 2 })
-})
+  t.deepEqual(a, { lineHeight: 2 });
+});
 
-test('lineHeight returns responsive line-height', t => {
+test("lineHeight returns responsive line-height", t => {
   const a = lineHeight({
     theme: {
-      lineHeights: [
-        1, 2, 3
-      ]
+      lineHeights: [1, 2, 3]
     },
     lineHeight: [1, 2]
-  })
+  });
 
   t.deepEqual(a, {
     lineHeight: 2,
-    '@media screen and (min-width: 40em)': {
-      lineHeight: 3,
+    "@media screen and (min-width: 40em)": {
+      lineHeight: 3
     }
-  })
-})
+  });
+});
 
 // fontWeight
-test('fontWeight returns fontWeight', t => {
-  const a = fontWeight({ fontWeight: 'bold' })
-  t.deepEqual(a, { fontWeight: 'bold' })
-})
+test("fontWeight returns fontWeight", t => {
+  const a = fontWeight({ fontWeight: "bold" });
+  t.deepEqual(a, { fontWeight: "bold" });
+});
 
-test('fontWeight returns a scalar style', t => {
+test("fontWeight returns a scalar style", t => {
   const a = fontWeight({
     theme: {
-      fontWeights: [
-        400, 600, 800
-      ]
+      fontWeights: [400, 600, 800]
     },
     fontWeight: 2
-  })
-  t.deepEqual(a, { fontWeight: 800 })
-})
+  });
+  t.deepEqual(a, { fontWeight: 800 });
+});
 
 // letterSpacing
-test('letterSpacing returns letterSpacing', t => {
-  const a = letterSpacing({ letterSpacing: 2 })
-  t.deepEqual(a, { letterSpacing: '2px' })
-})
+test("letterSpacing returns letterSpacing", t => {
+  const a = letterSpacing({ letterSpacing: 2 });
+  t.deepEqual(a, { letterSpacing: "2px" });
+});
 
-test('letterSpacing returns a scalar style', t => {
+test("letterSpacing returns a scalar style", t => {
   const a = letterSpacing({
     theme: {
-      letterSpacings: [
-        1, 2, 3
-      ]
+      letterSpacings: [1, 2, 3]
     },
     letterSpacing: 2
-  })
-  t.deepEqual(a, { letterSpacing: '3px' })
-})
+  });
+  t.deepEqual(a, { letterSpacing: "3px" });
+});
 
-test('display returns display', t => {
-  const a = display({ display: 'inline-block' })
-  t.is(a.display, 'inline-block')
-})
+test("display returns display", t => {
+  const a = display({ display: "inline-block" });
+  t.is(a.display, "inline-block");
+});
 
-test('minWidth returns minWidth', t => {
-  const a = minWidth({ minWidth: 256 })
-  t.is(a.minWidth, '256px')
-})
+test("minWidth returns minWidth", t => {
+  const a = minWidth({ minWidth: 256 });
+  t.is(a.minWidth, "256px");
+});
 
-test('maxWidth returns width styles', t => {
-  const a = maxWidth({ maxWidth: 234 })
-  t.deepEqual(a, { maxWidth: '234px' })
-})
+test("maxWidth returns width styles", t => {
+  const a = maxWidth({ maxWidth: 234 });
+  t.deepEqual(a, { maxWidth: "234px" });
+});
 
-test('maxWidth returns null when blank', t => {
-  const a = maxWidth({ maxWidth: null })
-  t.is(a, null)
-})
+test("maxWidth returns null when blank", t => {
+  const a = maxWidth({ maxWidth: null });
+  t.is(a, null);
+});
 
-test('maxWidth returns scalar styles', t => {
+test("maxWidth returns scalar styles", t => {
   const a = maxWidth({
     theme: {
-      maxWidths: [
-        123, 456, 789
-      ]
+      maxWidths: [123, 456, 789]
     },
     maxWidth: 1
-  })
-  t.deepEqual(a, { maxWidth: '456px' })
-})
+  });
+  t.deepEqual(a, { maxWidth: "456px" });
+});
 
-test('height returns height', t => {
-  const a = height({ height: 256 })
-  t.is(a.height, '256px')
-})
+test("height returns height", t => {
+  const a = height({ height: 256 });
+  t.is(a.height, "256px");
+});
 
-test('minHeight returns minHeight', t => {
-  const a = minHeight({ minHeight: 256 })
-  t.is(a.minHeight, '256px')
-})
+test("minHeight returns minHeight", t => {
+  const a = minHeight({ minHeight: 256 });
+  t.is(a.minHeight, "256px");
+});
 
-test('maxHeight returns maxHeight', t => {
-  const a = maxHeight({ maxHeight: 256 })
-  t.is(a.maxHeight, '256px')
-})
+test("maxHeight returns maxHeight", t => {
+  const a = maxHeight({ maxHeight: 256 });
+  t.is(a.maxHeight, "256px");
+});
 
-test('size returns width and height', t => {
-  const a = size({ size: 256 })
-  t.is(a.width, '256px')
-  t.is(a.height, '256px')
-})
+test("size returns width and height", t => {
+  const a = size({ size: 256 });
+  t.is(a.width, "256px");
+  t.is(a.height, "256px");
+});
 
-test('ratio returns height and paddingBottom', t => {
-  const a = ratio({ ratio: 1/2 })
-  t.is(a.height, 0)
-  t.is(a.paddingBottom, '50%')
-})
+test("ratio returns height and paddingBottom", t => {
+  const a = ratio({ ratio: 1 / 2 });
+  t.is(a.height, 0);
+  t.is(a.paddingBottom, "50%");
+});
 
-test('ratio returns null when undefined', t => {
-  const a = ratio({})
-  t.is(a, null)
-})
+test("ratio returns null when undefined", t => {
+  const a = ratio({});
+  t.is(a, null);
+});
 
-test('verticalAlign returns verticalAlign', t => {
-  const a = verticalAlign({ verticalAlign: 'middle' })
+test("verticalAlign returns verticalAlign", t => {
+  const a = verticalAlign({ verticalAlign: "middle" });
   t.deepEqual(a, {
-    verticalAlign: 'middle'
-  })
-})
+    verticalAlign: "middle"
+  });
+});
 
-test('alignItems returns a style', t => {
-  const a = alignItems({ alignItems: 'center' })
-  t.deepEqual(a, { alignItems: 'center' })
-})
+test("alignItems returns a style", t => {
+  const a = alignItems({ alignItems: "center" });
+  t.deepEqual(a, { alignItems: "center" });
+});
 
-test('alignContent returns a style', t => {
-  const a = alignContent({ alignContent: 'center' })
-  t.deepEqual(a, { alignContent: 'center' })
-})
+test("alignContent returns a style", t => {
+  const a = alignContent({ alignContent: "center" });
+  t.deepEqual(a, { alignContent: "center" });
+});
 
-test('justifyContent returns a style', t => {
-  const a = justifyContent({ justifyContent: 'center' })
-  t.deepEqual(a, { justifyContent: 'center' })
-})
+test("justifyContent returns a style", t => {
+  const a = justifyContent({ justifyContent: "center" });
+  t.deepEqual(a, { justifyContent: "center" });
+});
 
-test('flexWrap returns a style', t => {
-  const a = flexWrap({ flexWrap: 'wrap' })
-  t.deepEqual(a, { flexWrap: 'wrap' })
-})
+test("flexWrap returns a style", t => {
+  const a = flexWrap({ flexWrap: "wrap" });
+  t.deepEqual(a, { flexWrap: "wrap" });
+});
 
-test('flexDirection returns a style', t => {
-  const a = flexDirection({ flexDirection: 'column' })
-  t.deepEqual(a, { flexDirection: 'column' })
-})
+test("flexDirection returns a style", t => {
+  const a = flexDirection({ flexDirection: "column" });
+  t.deepEqual(a, { flexDirection: "column" });
+});
 
-test('flex returns a style', t => {
-  const a = flex({ flex: 'none' })
-  t.deepEqual(a, { flex: 'none' })
-})
+test("flex returns a style", t => {
+  const a = flex({ flex: "none" });
+  t.deepEqual(a, { flex: "none" });
+});
 
-test('justifySelf returns a style', t => {
-  const a = justifySelf({ justifySelf: 'center' })
-  t.deepEqual(a, { justifySelf: 'center' })
-})
+test("justifySelf returns a style", t => {
+  const a = justifySelf({ justifySelf: "center" });
+  t.deepEqual(a, { justifySelf: "center" });
+});
 
-test('alignSelf returns a style', t => {
-  const a = alignSelf({ alignSelf: 'center' })
-  t.deepEqual(a, { alignSelf: 'center' })
-})
+test("alignSelf returns a style", t => {
+  const a = alignSelf({ alignSelf: "center" });
+  t.deepEqual(a, { alignSelf: "center" });
+});
 
-test('order returns a style', t => {
-  const a = order({ order: 2 })
-  t.deepEqual(a, { order: 2 })
-})
+test("order returns a style", t => {
+  const a = order({ order: 2 });
+  t.deepEqual(a, { order: 2 });
+});
 
-test('gridGap returns a scalar style', t => {
+test("gridGap returns a scalar style", t => {
   const a = gridGap({
     theme: {
-      space: [
-        0, 2, 4, 8
-      ]
+      space: [0, 2, 4, 8]
     },
     gridGap: 3
-  })
+  });
 
-  t.deepEqual(a, { gridGap: '8px' })
-})
+  t.deepEqual(a, { gridGap: "8px" });
+});
 
-test('gridRowGap returns a scalar style', t => {
+test("gridRowGap returns a scalar style", t => {
   const a = gridRowGap({
     theme: {
-      space: [
-        0, 2, 4, 8
-      ]
+      space: [0, 2, 4, 8]
     },
     gridRowGap: 3
-  })
+  });
 
-  t.deepEqual(a, { gridRowGap: '8px' })
-})
+  t.deepEqual(a, { gridRowGap: "8px" });
+});
 
-test('gridColumnGap returns a scalar style', t => {
+test("gridColumnGap returns a scalar style", t => {
   const a = gridColumnGap({
     theme: {
-      space: [
-        0, 2, 4, 8
-      ]
+      space: [0, 2, 4, 8]
     },
     gridColumnGap: 3
-  })
+  });
 
-  t.deepEqual(a, { gridColumnGap: '8px' })
-})
+  t.deepEqual(a, { gridColumnGap: "8px" });
+});
 
-test('gridAutoFlow returns a style', t => {
-  const a = gridAutoFlow({ gridAutoFlow: 'row dense' })
-  t.deepEqual(a, { gridAutoFlow: 'row dense' })
-})
+test("gridAutoFlow returns a style", t => {
+  const a = gridAutoFlow({ gridAutoFlow: "row dense" });
+  t.deepEqual(a, { gridAutoFlow: "row dense" });
+});
 
-test('gridAutoRows returns a style', t => {
-  const a = gridAutoRows({ gridAutoRows: 'auto' })
-  t.deepEqual(a, { gridAutoRows: 'auto' })
-})
+test("gridAutoRows returns a style", t => {
+  const a = gridAutoRows({ gridAutoRows: "auto" });
+  t.deepEqual(a, { gridAutoRows: "auto" });
+});
 
-test('gridAutoColumns returns a style', t => {
-  const a = gridAutoColumns({ gridAutoColumns: 'auto' })
-  t.deepEqual(a, { gridAutoColumns: 'auto' })
-})
+test("gridAutoColumns returns a style", t => {
+  const a = gridAutoColumns({ gridAutoColumns: "auto" });
+  t.deepEqual(a, { gridAutoColumns: "auto" });
+});
 
-test('gridTemplateColumns returns a style', t => {
-  const a = gridTemplateColumns({ gridTemplateColumns: '1fr 1fr' })
-  t.deepEqual(a, { gridTemplateColumns: '1fr 1fr' })
-})
+test("gridTemplateColumns returns a style", t => {
+  const a = gridTemplateColumns({ gridTemplateColumns: "1fr 1fr" });
+  t.deepEqual(a, { gridTemplateColumns: "1fr 1fr" });
+});
 
-test('gridTemplateRows returns a style', t => {
-  const a = gridTemplateRows({ gridTemplateRows: '1fr 1fr' })
-  t.deepEqual(a, { gridTemplateRows: '1fr 1fr' })
-})
+test("gridTemplateRows returns a style", t => {
+  const a = gridTemplateRows({ gridTemplateRows: "1fr 1fr" });
+  t.deepEqual(a, { gridTemplateRows: "1fr 1fr" });
+});
 
-test('gridColumn returns a style', t => {
-  const a = gridColumn({ gridColumn: 'span 2' })
-  t.deepEqual(a, { gridColumn: 'span 2' })
-})
+test("gridColumn returns a style", t => {
+  const a = gridColumn({ gridColumn: "span 2" });
+  t.deepEqual(a, { gridColumn: "span 2" });
+});
 
-test('gridRow returns a style', t => {
-  const a = gridRow({ gridRow: 'span 2' })
-  t.deepEqual(a, { gridRow: 'span 2' })
-})
+test("gridRow returns a style", t => {
+  const a = gridRow({ gridRow: "span 2" });
+  t.deepEqual(a, { gridRow: "span 2" });
+});
 
-test('borderRadius returns borderRadius', t => {
-  const a = borderRadius({ borderRadius: '4px' })
-  t.deepEqual(a, { borderRadius: '4px' })
-})
+test("borderRadius returns borderRadius", t => {
+  const a = borderRadius({ borderRadius: "4px" });
+  t.deepEqual(a, { borderRadius: "4px" });
+});
 
-test('borderRadius returns a pixel value', t => {
-  const a = borderRadius({ borderRadius: 4 })
-  t.deepEqual(a, { borderRadius: '4px' })
-})
+test("borderRadius returns a pixel value", t => {
+  const a = borderRadius({ borderRadius: 4 });
+  t.deepEqual(a, { borderRadius: "4px" });
+});
 
-test('borderRadius returns a pixel value from theme', t => {
+test("borderRadius returns a pixel value from theme", t => {
   const a = borderRadius({
     theme,
     borderRadius: 0
-  })
-  t.deepEqual(a, { borderRadius: '2px' })
-})
+  });
+  t.deepEqual(a, { borderRadius: "2px" });
+});
 
-test('borderColor returns borderColor', t => {
-  const a = borderColor({ borderColor: 'blue' })
-  t.deepEqual(a, { borderColor: 'blue' })
-})
+test("borderColor returns borderColor", t => {
+  const a = borderColor({ borderColor: "blue" });
+  t.deepEqual(a, { borderColor: "blue" });
+});
 
-test('borderColor returns nested borderColor', t => {
-  const a = borderColor({ theme, borderColor: 'gray.0' })
-  t.deepEqual(a, { borderColor: theme.colors.gray[0] })
-})
+test("borderColor returns nested borderColor", t => {
+  const a = borderColor({ theme, borderColor: "gray.0" });
+  t.deepEqual(a, { borderColor: theme.colors.gray[0] });
+});
 
-test('borders returns a border shorthand style', t => {
-  const a = borders({ border: '1px solid' })
-  t.is(a.border, '1px solid')
-})
+test("borders returns a border shorthand style", t => {
+  const a = borders({ border: "1px solid" });
+  t.is(a.border, "1px solid");
+});
 
-test('borders converts numbers to a border shorthand style', t => {
-  const a = borders({ border: 1 })
-  t.is(a.border, '1px solid')
-})
+test("borders converts numbers to a border shorthand style", t => {
+  const a = borders({ border: 1 });
+  t.is(a.border, "1px solid");
+});
 
-test('borders handles responsive styles', t => {
-  const a = borders({ border: [ 0, 1 ] })
-  t.is(a.border, 0)
-  t.is(a['@media screen and (min-width: 40em)'].border , '1px solid')
-})
+test("borders handles responsive styles", t => {
+  const a = borders({ border: [0, 1] });
+  t.is(a.border, 0);
+  t.is(a["@media screen and (min-width: 40em)"].border, "1px solid");
+});
 
-test('borders converts borderTop shorthand styles', t => {
-  const a = borders({ borderTop: '1px solid' })
-  t.is(a.borderTop, '1px solid')
-})
+test("borders converts borderTop shorthand styles", t => {
+  const a = borders({ borderTop: "1px solid" });
+  t.is(a.borderTop, "1px solid");
+});
 
-test('borders converts borderTop number shorthand styles', t => {
-  const a = borders({ borderTop: 1 })
-  t.is(a.borderTop, '1px solid')
-})
+test("borders converts borderTop number shorthand styles", t => {
+  const a = borders({ borderTop: 1 });
+  t.is(a.borderTop, "1px solid");
+});
 
-test('borders converts borderRight shorthand styles', t => {
-  const a = borders({ borderRight: '1px solid' })
-  t.is(a.borderRight, '1px solid')
-})
+test("borders converts borderRight shorthand styles", t => {
+  const a = borders({ borderRight: "1px solid" });
+  t.is(a.borderRight, "1px solid");
+});
 
-test('borders converts borderRight number shorthand styles', t => {
-  const a = borders({ borderRight: 1 })
-  t.is(a.borderRight, '1px solid')
-})
+test("borders converts borderRight number shorthand styles", t => {
+  const a = borders({ borderRight: 1 });
+  t.is(a.borderRight, "1px solid");
+});
 
-test('borders converts borderBottom shorthand styles', t => {
-  const a = borders({ borderBottom: '1px solid' })
-  t.is(a.borderBottom, '1px solid')
-})
+test("borders converts borderBottom shorthand styles", t => {
+  const a = borders({ borderBottom: "1px solid" });
+  t.is(a.borderBottom, "1px solid");
+});
 
-test('borders converts borderBottom number shorthand styles', t => {
-  const a = borders({ borderBottom: 1 })
-  t.is(a.borderBottom, '1px solid')
-})
+test("borders converts borderBottom number shorthand styles", t => {
+  const a = borders({ borderBottom: 1 });
+  t.is(a.borderBottom, "1px solid");
+});
 
-test('borders converts borderLeft shorthand styles', t => {
-  const a = borders({ borderLeft: '1px solid' })
-  t.is(a.borderLeft, '1px solid')
-})
+test("borders converts borderLeft shorthand styles", t => {
+  const a = borders({ borderLeft: "1px solid" });
+  t.is(a.borderLeft, "1px solid");
+});
 
-test('borders converts borderLeft number shorthand styles', t => {
-  const a = borders({ borderLeft: 1 })
-  t.is(a.borderLeft, '1px solid')
-})
+test("borders converts borderLeft number shorthand styles", t => {
+  const a = borders({ borderLeft: 1 });
+  t.is(a.borderLeft, "1px solid");
+});
 
-test('borders combines multiple border styles', t => {
+test("borders combines multiple border styles", t => {
   const a = borders({
     borderTop: 1,
     borderBottom: 2
-  })
-  t.is(a.borderTop, '1px solid')
-  t.is(a.borderBottom, '2px solid')
-})
+  });
+  t.is(a.borderTop, "1px solid");
+  t.is(a.borderBottom, "2px solid");
+});
 
-test('borders combines multiple responsive styles', t => {
+test("borders combines multiple responsive styles", t => {
   const a = borders({
-    borderTop: [ '1px solid', '2px solid' ],
-    borderBottom: [ 'none', '2px solid' ],
-  })
+    borderTop: ["1px solid", "2px solid"],
+    borderBottom: ["none", "2px solid"]
+  });
   t.deepEqual(a, {
-    borderTop: '1px solid',
-    borderBottom: 'none',
-    '@media screen and (min-width: 40em)': {
-      borderTop: '2px solid',
-      borderBottom: '2px solid',
+    borderTop: "1px solid",
+    borderBottom: "none",
+    "@media screen and (min-width: 40em)": {
+      borderTop: "2px solid",
+      borderBottom: "2px solid"
     }
-  })
-})
+  });
+});
 
-test('boxShadow returns box-shadow styles', t => {
-  const a = boxShadow({ boxShadow: '0 0 8px rgba(0, 0, 0, .125)' })
-  t.deepEqual(a, { boxShadow: '0 0 8px rgba(0, 0, 0, .125)' })
-})
+test("boxShadow returns box-shadow styles", t => {
+  const a = boxShadow({ boxShadow: "0 0 8px rgba(0, 0, 0, .125)" });
+  t.deepEqual(a, { boxShadow: "0 0 8px rgba(0, 0, 0, .125)" });
+});
 
-test('boxShadow returns theme value', t => {
+test("boxShadow returns theme value", t => {
   const a = boxShadow({
     theme: {
-      shadows: [
-        '0 0 4px rgba(0, 0, 0, .125)',
-        '0 0 8px rgba(0, 0, 0, .125)',
-      ]
+      shadows: ["0 0 4px rgba(0, 0, 0, .125)", "0 0 8px rgba(0, 0, 0, .125)"]
     },
     boxShadow: 1
-  })
-  t.deepEqual(a, { boxShadow: '0 0 8px rgba(0, 0, 0, .125)' })
-})
+  });
+  t.deepEqual(a, { boxShadow: "0 0 8px rgba(0, 0, 0, .125)" });
+});
 
-test('opacity returns opacity styles', t => {
-  const a = opacity({ opacity: 0.5 })
-  t.deepEqual(a, { opacity: 0.5 })
-})
+test("opacity returns opacity styles", t => {
+  const a = opacity({ opacity: 0.5 });
+  t.deepEqual(a, { opacity: 0.5 });
+});
 
-test('background returns background', t => {
-  const a = background({ background: 'tomato' })
-  t.is(a.background, 'tomato')
-})
+test("background returns background", t => {
+  const a = background({ background: "tomato" });
+  t.is(a.background, "tomato");
+});
 
-test('backgroundImage returns backgroundImage', t => {
-  const a = backgroundImage({ backgroundImage: 'url(kitten.png)' })
-  t.is(a.backgroundImage, 'url(kitten.png)')
-})
+test("backgroundImage returns backgroundImage", t => {
+  const a = backgroundImage({ backgroundImage: "url(kitten.png)" });
+  t.is(a.backgroundImage, "url(kitten.png)");
+});
 
-test('backgroundSize returns backgroundSize', t => {
-  const a = backgroundSize({ backgroundSize: 'cover' })
-  t.is(a.backgroundSize, 'cover')
-})
+test("backgroundSize returns backgroundSize", t => {
+  const a = backgroundSize({ backgroundSize: "cover" });
+  t.is(a.backgroundSize, "cover");
+});
 
-test('backgroundPosition returns backgroundPosition', t => {
-  const a = backgroundPosition({ backgroundPosition: 'center' })
-  t.is(a.backgroundPosition, 'center')
-})
+test("backgroundPosition returns backgroundPosition", t => {
+  const a = backgroundPosition({ backgroundPosition: "center" });
+  t.is(a.backgroundPosition, "center");
+});
 
-test('backgroundRepeat returns backgroundRepeat', t => {
-  const a = backgroundRepeat({ backgroundRepeat: 'repeat' })
-  t.is(a.backgroundRepeat, 'repeat')
-})
+test("backgroundRepeat returns backgroundRepeat", t => {
+  const a = backgroundRepeat({ backgroundRepeat: "repeat" });
+  t.is(a.backgroundRepeat, "repeat");
+});
 
-test('position returns position', t => {
-  const a = position({ position: 'absolute' })
-  t.is(a.position, 'absolute')
-})
+test("position returns position", t => {
+  const a = position({ position: "absolute" });
+  t.is(a.position, "absolute");
+});
 
-test('zIndex returns zIndex', t => {
-  const a = zIndex({ zIndex: 2 })
-  t.is(a.zIndex, 2)
-})
+test("zIndex returns zIndex", t => {
+  const a = zIndex({ zIndex: 2 });
+  t.is(a.zIndex, 2);
+});
 
-test('top returns top', t => {
-  const a = top({ top: 2 })
-  t.is(a.top, '2px')
-})
+test("top returns top", t => {
+  const a = top({ top: 2 });
+  t.is(a.top, "2px");
+});
 
-test('right returns right', t => {
-  const a = right({ right: 2 })
-  t.is(a.right, '2px')
-})
+test("right returns right", t => {
+  const a = right({ right: 2 });
+  t.is(a.right, "2px");
+});
 
-test('bottom returns bottom', t => {
-  const a = bottom({ bottom: 2 })
-  t.is(a.bottom, '2px')
-})
+test("bottom returns bottom", t => {
+  const a = bottom({ bottom: 2 });
+  t.is(a.bottom, "2px");
+});
 
-test('left returns left', t => {
-  const a = left({ left: 2 })
-  t.is(a.left, '2px')
-})
+test("left returns left", t => {
+  const a = left({ left: 2 });
+  t.is(a.left, "2px");
+});
 
-test('responsive props can have falsey values', t => {
-  const dec = space({m: [null, 1]})
+test("responsive props can have falsey values", t => {
+  const dec = space({ m: [null, 1] });
   t.deepEqual(dec, {
-    '@media screen and (min-width: 40em)': {
-      margin: '4px'
+    "@media screen and (min-width: 40em)": {
+      margin: "4px"
     }
-  })
-})
+  });
+});
 
-test('textStyle returns a value from theme', t => {
+test("textStyle returns a value from theme", t => {
   const theme = {
     textStyles: {
       caps: {
-        fontSize: '12px',
-        textTransform: 'uppercase',
-        letterSpacing: '0.2em'
+        fontSize: "12px",
+        textTransform: "uppercase",
+        letterSpacing: "0.2em"
       }
     }
-  }
-  const a = textStyle({ textStyle: 'caps', theme })
-  t.deepEqual(a, theme.textStyles.caps)
-})
+  };
+  const a = textStyle({ textStyle: "caps", theme });
+  t.deepEqual(a, theme.textStyles.caps);
+});
 
-test('colorStyle returns a value from theme', t => {
+test("colorStyle returns a value from theme", t => {
   const theme = {
     colorStyles: {
       primary: {
-        color: 'white',
-        backgroundColor: 'tomato',
+        color: "white",
+        backgroundColor: "tomato"
       }
     }
-  }
-  const a = colorStyle({ colors: 'primary', theme })
-  t.deepEqual(a, theme.colorStyles.primary)
-})
+  };
+  const a = colorStyle({ colors: "primary", theme });
+  t.deepEqual(a, theme.colorStyles.primary);
+});
 
-test('buttonStyle returns a value from theme', t => {
+test("buttonStyle returns a value from theme", t => {
   const theme = {
     buttons: {
       primary: {
-        color: 'white',
-        backgroundColor: 'tomato',
-        '&:hover': {
-          backgroundColor: 'black'
+        color: "white",
+        backgroundColor: "tomato",
+        "&:hover": {
+          backgroundColor: "black"
         }
       }
     }
-  }
-  const a = buttonStyle({ variant: 'primary', theme })
-  t.deepEqual(a, theme.buttons.primary)
-})
+  };
+  const a = buttonStyle({ variant: "primary", theme });
+  t.deepEqual(a, theme.buttons.primary);
+});
 
-test('variant returns a value from theme', t => {
+test("variant returns a value from theme", t => {
   const theme = {
     buttons: {
       primary: {
-        backgroundColor: 'tomato'
+        backgroundColor: "tomato"
       }
     }
-  }
-  const a = variant({ key: 'buttons' })({ theme, variant: 'primary' })
-  t.deepEqual(a, theme.buttons.primary)
-})
+  };
+  const a = variant({ key: "buttons" })({ theme, variant: "primary" });
+  t.deepEqual(a, theme.buttons.primary);
+});
 
-test('variant returns null', t => {
-  const theme = {}
-  const a = variant({ key: 'buttons' })({ theme, variant: 'primary' })
-  t.is(a, null)
-})
+test("variant returns null", t => {
+  const theme = {};
+  const a = variant({ key: "buttons" })({ theme, variant: "primary" });
+  t.is(a, null);
+});
 
-test('mixed returns a style object', t => {
-  const a = mixed({ backgroundColor: 'tomato' })
-  t.deepEqual(a, { backgroundColor: 'tomato' })
-})
+test("mixed returns a style object", t => {
+  const a = mixed({ backgroundColor: "tomato" });
+  t.deepEqual(a, { backgroundColor: "tomato" });
+});
 
-test('mixed returns prop-based styles', t => {
-  const a = mixed({ bg: 'tomato' })
-  t.deepEqual(a, { backgroundColor: 'tomato' })
-})
+test("mixed returns prop-based styles", t => {
+  const a = mixed({ bg: "tomato" });
+  t.deepEqual(a, { backgroundColor: "tomato" });
+});
 
-test('mixed returns theme-based styles', t => {
-  const a = mixed({ theme, bg: 'blue' })
-  t.deepEqual(a, { backgroundColor: theme.colors.blue })
-})
+test("mixed returns theme-based styles", t => {
+  const a = mixed({ theme, bg: "blue" });
+  t.deepEqual(a, { backgroundColor: theme.colors.blue });
+});
 
 Object.keys(styles).forEach(key => {
   test(`${key}.propTypes is an object`, t => {
-    const fn = system[key]
-    if (typeof fn !== 'function') return t.pass()
-    t.is(typeof fn.propTypes, 'object')
+    const fn = system[key];
+    if (typeof fn !== "function") return t.pass();
+    t.is(typeof fn.propTypes, "object");
     Object.keys(fn.propTypes).forEach(prop => {
-      t.is(typeof fn.propTypes[prop], 'function')
-    })
-  })
-})
+      t.is(typeof fn.propTypes[prop], "function");
+    });
+  });
+});


### PR DESCRIPTION
This uses the internal `get` helper to allow nested property access in `space`, rather than direct. This way space is ambivalent to the data structure of the theme, like other props are.

Are there other props that could use the same treatment?

Fixes #351