### PR TITLE
added renderStyledSystemProps helper

### DIFF
--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -28,13 +28,13 @@ All style utilities add props that accept arrays as values for mobile-first resp
 <Box p={[ 1, 2, 3, 4 ]} />
 ```
 
-To inject responsive props into a styled component, use the `renderStyledSystemProp` helper:
+To inject responsive props into a styled component, use the `renderStyledSystemProps` helper:
 ```jsx
 import styled from 'styled-components';
-import { renderStyledSystemProp } from 'styled-system';
+import { renderStyledSystemProps } from 'styled-system';
 
 const ResponsiveStyledComponent = styled.div`
-  ${renderStyledSystemProp({ p : ['0px', '8px', '16px']})}
+  ${renderStyledSystemProps({ p : ['0px', '8px', '16px']})}
 `
 
 ```

--- a/docs/responsive-styles.md
+++ b/docs/responsive-styles.md
@@ -28,3 +28,13 @@ All style utilities add props that accept arrays as values for mobile-first resp
 <Box p={[ 1, 2, 3, 4 ]} />
 ```
 
+To inject responsive props into a styled component, use the `renderStyledSystemProp` helper:
+```jsx
+import styled from 'styled-components';
+import { renderStyledSystemProp } from 'styled-system';
+
+const ResponsiveStyledComponent = styled.div`
+  ${renderStyledSystemProp({ p : ['0px', '8px', '16px']})}
+`
+
+```

--- a/src/index.js
+++ b/src/index.js
@@ -723,14 +723,14 @@ export const mixed = props => funcs
   .map(fn => fn(props))
   .reduce(merge, omit(props, blacklist))
 
-export const renderStyledSystemProps = styledSystemPropObject => props => {
+export const renderStyledSystemProps = (styledSystemPropObject = {}) => (props = {}) => {
   return Object.entries(styledSystemPropObject)
     .reduce((styleObject, [propKey, propValue]) => {
       if (styles[propKey]) {
         return merge(styleObject, styles[propKey]({ [propKey]: propValue, ...props }));
-      } else if (color.propTypes.includes(propKey)) {
+      } else if (Object.keys(color.propTypes).includes(propKey)) {
         return merge(styleObject, styles.color({ [propKey]: propValue, ...props }));
-      } else if (space.propTypes.includes(propKey)) {
+      } else if (Object.keys(space.propTypes).includes(propKey)) {
         return merge(styleObject, styles.space({ [propKey]: propValue, ...props }));
       }
       return styleObject;

--- a/src/index.js
+++ b/src/index.js
@@ -723,7 +723,7 @@ export const mixed = props => funcs
   .map(fn => fn(props))
   .reduce(merge, omit(props, blacklist))
 
-export const renderStyledSystemProp = styledSystemPropObject => props => {
+export const renderStyledSystemProps = styledSystemPropObject => props => {
   return Object.entries(styledSystemPropObject)
     .reduce((styleObject, [propKey, propValue]) => {
       if (styles[propKey]) {

--- a/src/index.js
+++ b/src/index.js
@@ -722,3 +722,18 @@ const blacklist = funcs.reduce((a, fn) => [
 export const mixed = props => funcs
   .map(fn => fn(props))
   .reduce(merge, omit(props, blacklist))
+
+export const renderStyledSystemProp = styledSystemPropObject => props => {
+  return Object.entries(styledSystemPropObject)
+    .reduce((styleObject, [propKey, propValue]) => {
+      if (styles[propKey]) {
+        return merge(styleObject, styles[propKey]({ [propKey]: propValue, ...props }));
+      } else if (color.propTypes.includes(propKey)) {
+        return merge(styleObject, styles.color({ [propKey]: propValue, ...props }));
+      } else if (space.propTypes.includes(propKey)) {
+        return merge(styleObject, styles.space({ [propKey]: propValue, ...props }));
+      }
+      return styleObject;
+    }, {});
+  };
+  

--- a/src/index.js
+++ b/src/index.js
@@ -736,4 +736,3 @@ export const renderStyledSystemProps = (styledSystemPropObject = {}) => (props =
       return styleObject;
     }, {});
   };
-  

--- a/test/index.js
+++ b/test/index.js
@@ -1292,6 +1292,10 @@ test('renderStyledSystemProps returns an empty object if nothing is passed in', 
   t.deepEqual(renderStyledSystemProps({})({}), {});
 });
 
+test('renderStyledSystemProps returns an empty object if there is no match to a style prop', t => {
+  t.deepEqual(renderStyledSystemProps({ foo: 'bar' })(), {});
+});
+
 test('renderStyledSystemProps converts styled system specific props into generic style props', t => {
   // Test a standard style, "fontSize"
 

--- a/test/index.js
+++ b/test/index.js
@@ -1285,6 +1285,69 @@ Object.keys(styles).forEach(key => {
   })
 })
 
+test('renderStyledSystemProps returns an empty object if nothing is passed in', t => {
+  t.deepEqual(renderStyledSystemProps(  )(  ), {});
+  t.deepEqual(renderStyledSystemProps({})(  ), {});
+  t.deepEqual(renderStyledSystemProps(  )({}), {});
+  t.deepEqual(renderStyledSystemProps({})({}), {});
+});
+
 test('renderStyledSystemProps converts styled system specific props into generic style props', t => {
-  // Need to do something better here
+  // Test a standard style, "fontSize"
+
+  // It renders with only a styled system object passed in
+  t.deepEqual(
+    renderStyledSystemProps({ fontSize: '14px' })(),
+    { fontSize: '14px' }
+  );
+
+  // It renders with only a responsive styled system object passed in
+  t.deepEqual(
+    renderStyledSystemProps({ fontSize: ['14px', '18px', '22px'] })(),
+    {
+      fontSize: '14px',
+      '@media screen and (min-width: 40em)': { fontSize: '18px' },
+      '@media screen and (min-width: 52em)': { fontSize: '22px' }
+    }
+  );
+
+  // It renders with a responsive styled system object overwritten by a nonresponsive prop
+  t.deepEqual(
+    renderStyledSystemProps({ fontSize: ['14px', '18px', '22px'] })({ fontSize: '25px' }),
+    {
+      fontSize: '25px'
+    }
+  );
+
+  // It renders with a responsive styled system object overwritten by a responsive prop
+  t.deepEqual(
+    renderStyledSystemProps({ fontSize: ['14px', '18px', '22px'] })({ fontSize: ['20px', '24px', '28px'] }),
+    {
+      fontSize: '20px',
+      '@media screen and (min-width: 40em)': { fontSize: '24px' },
+      '@media screen and (min-width: 52em)': { fontSize: '28px' }
+    }
+  );
+
+  // It renders with a nonresponsive styled system object overwritten by a responsive prop
+  t.deepEqual(
+    renderStyledSystemProps({ fontSize: '14px' })({ fontSize: ['20px', '24px', '28px'] }),
+    {
+      fontSize: '20px',
+      '@media screen and (min-width: 40em)': { fontSize: '24px' },
+      '@media screen and (min-width: 52em)': { fontSize: '28px' }
+    }
+  );
+
+  // It renders the bg prop correctly
+  const bgProps = renderStyledSystemProps({ bg: 'red' })();
+  t.deepEqual(bgProps, { backgroundColor: 'red' });
+
+  // It renders the bg prop correctly with a theme
+  const bgThemeProps = renderStyledSystemProps({ bg: 'blue' })({ theme });
+  t.deepEqual(bgThemeProps, { backgroundColor: '#07c' });
+  
+  // It renders a "space" prop correctly
+  const pyProps = renderStyledSystemProps({ py: '10px' })();
+  t.deepEqual(pyProps, { paddingTop: '10px', paddingBottom: '10px' });
 })

--- a/test/index.js
+++ b/test/index.js
@@ -78,7 +78,7 @@ import {
   colorStyle,
   buttonStyle,
 
-  renderStyledSystemProp
+  renderStyledSystemProps
 } from '../src'
 
 const theme = {
@@ -1285,6 +1285,6 @@ Object.keys(styles).forEach(key => {
   })
 })
 
-test('renderStyledSystemProp converts styled system specific props into generic style props', t => {
+test('renderStyledSystemProps converts styled system specific props into generic style props', t => {
   // Need to do something better here
 })

--- a/test/index.js
+++ b/test/index.js
@@ -77,6 +77,8 @@ import {
   textStyle,
   colorStyle,
   buttonStyle,
+
+  renderStyledSystemProp
 } from '../src'
 
 const theme = {
@@ -1281,4 +1283,8 @@ Object.keys(styles).forEach(key => {
       t.is(typeof fn.propTypes[prop], 'function')
     })
   })
+})
+
+test('renderStyledSystemProp converts styled system specific props into generic style props', t => {
+  // Need to do something better here
 })


### PR DESCRIPTION
If I am creating a reusable component with responsive styles, I will want to declare the styles directly inside of the styled component.

For example:
```jsx
const Section = styled.div`
  ${space}
`
```

I can inject responsive styles with an extra function like this:
```jsx
const ResponsiveSection = props => <Section {...props} py={['192px', '224px', '320px']} />;
```

Or I could use `@rebass/components` and do something like this:
```jsx
const Section = system(
  {
    py: ['192px', '224px', '320px'],
  },
  'space',
);
```

Or, per @flybayer's advice, I could use default props like this:
```jsx
const Section = styled.div`
  ${space}
`
Section.defaultProps = {
  py: ['192px', '224px', '320px']
};
```

The goal of this PR is to avoid the workflows described above and instead add a helper function for rendering `styled-system` props inside of a styled component.

Usage of the helper function would look like this:
 ```jsx
 import styled from 'styled-components';
 import { renderStyledSystemProps } from 'styled-system';
 
 const ResponsiveStyledComponent = styled.div`
   ${renderStyledSystemProps({ py: ['192px', '224px', '320px'] })}
 ` 
 ```