### PR TITLE
Allow breakpoint array to be used together with breakpoint object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,9 +66,17 @@ const getStyles = ({ props, style, value }) => {
   }
 
   // how to hoist this up??
-  const breakpoints = get(props.theme, 'breakpoints') || defaultBreakpoints
+  let breakpoints = get(props.theme, 'breakpoints') || defaultBreakpoints
 
   if (isArray(value)) {
+    if (!isArray(breakpoints)) {
+      breakpoints = Object.keys(breakpoints).reduce((accum, key, i) => {
+        if (breakpoints[key]) {
+          accum.push(breakpoints[key])
+        }
+        return accum
+      }, [])
+    }
     const styles = style(value[0]) || {}
     for (let i = 1; i < value.length; i++) {
       const rule = style(value[i])

--- a/test/index.js
+++ b/test/index.js
@@ -356,6 +356,20 @@ test('space can accept a breakpoint map (object)', t => {
   })
 })
 
+test('space can accept a breakpoint array, with fallback to breakpoint map (object)', t => {
+  const a = space({
+    theme: { breakpoints: { xs: 0, sm: '40em', md: '50em', lg: '60em' } },
+    p: [1, null, 2],
+  })
+
+  t.deepEqual(a, {
+    padding: '4px',
+    '@media screen and (min-width: 50em)': {
+      padding: '8px',
+    },
+  })
+})
+
 test('space returns responsive directional paddings', t => {
   const a = space({ pt: [0, 1], pb: [2, 3] })
   t.deepEqual(a, {
@@ -736,6 +750,22 @@ test('style allows a breakpoint map without a default', t => {
   const a = direction({
     theme: { breakpoints: { sm: '40em', md: '50em' } },
     direction: { md: 'column' },
+  })
+  t.deepEqual(a, {
+    '@media screen and (min-width: 50em)': {
+      'flex-direction': 'column',
+    },
+  })
+})
+
+test('style allows a breakpoint array falling back to breakpoint object', t => {
+  const direction = style({
+    cssProperty: 'flex-direction',
+    prop: 'direction',
+  })
+  const a = direction({
+    theme: { breakpoints: { xs: 0, sm: '40em', md: '50em' } },
+    direction: [null, null, 'column'],
   })
   t.deepEqual(a, {
     '@media screen and (min-width: 50em)': {


### PR DESCRIPTION
We would really like to use the new breakpoint object syntax (https://github.com/jxnblk/styled-system/pull/341), but currently we have a ton props using the array syntax (`[1, null, null, 2`]). If we could take an incremental upgrade approach, it would make the transition much easier. 

If there is another way doing this, feel free to discard.

Otherwise, mad props for this lib 👍 

cc @WebSeed