### PR TITLE
Add bootstrap support to system-classnames

### DIFF
--- a/packages/system-classnames/README.md
+++ b/packages/system-classnames/README.md
@@ -56,6 +56,10 @@ import map from 'system-classnames/tachyons'
 import map from 'system-classnames/primer'
 ```
 
+```jsx
+import map from 'system-classnames/bootstrap'
+```
+
 ### Related
 
 - [Basscss](http://basscss.com)

--- a/packages/system-classnames/bootstrap.js
+++ b/packages/system-classnames/bootstrap.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/bootstrap@4.2')

--- a/packages/system-classnames/src/bootstrap@4.2.js
+++ b/packages/system-classnames/src/bootstrap@4.2.js
@@ -1,0 +1,73 @@
+import createMapper from './index'
+
+const breakpoints = [ null, 'sm', 'md', 'lg', 'xl' ]
+const propsSupportingBreakpoints = [
+  'col', 'order', 'offset',
+  'd',
+
+  'flex',
+  // flex-row and flex-wrap can be used at the same time
+  // flex=['row wrap']
+
+  'justifyContent', 'alignItems', 'alignContent', 'alignSelf',
+  'float',
+
+  'm', 'mt', 'mr', 'mb', 'ml', 'mx', 'my',
+  'p', 'pt', 'pr', 'pb', 'pl', 'px', 'py',
+
+  'text', // breakpoints supported supported for: left right center
+]
+const propsWithDuplicatedClassNames = ['embedResponsive', 'border']
+const otherUtilityProps = [
+  'bg',
+  'borderTop', 'borderRight', 'borderBottom', 'borderLeft',
+  'rounded', 'roundedTop', 'roundedRight', 'roundedBottom', 'roundedLeft', 'roundedCircle', 'roundedPill',
+  'clearfix',
+  'dPrint',
+  'overflow',
+  'position', 'fixed', 'sticky',
+  'srOnly', 'srOnlyFocusable',
+  'shadow',
+  'w', 'h', 'mw', 'mh', 'minVw', 'minVh', 'vw', 'vh',
+  'align',
+  'visible', 'invisible'
+]
+
+const className = ({kebabProp, breakpoint, value}) =>
+  value
+    .toString()
+    .split(' ')
+    .map(value =>
+      [
+        kebabProp,
+        breakpoint,
+        value === 'true' ? undefined : value
+      ]
+      .filter(Boolean)
+      .join('-')
+    )
+    .join(' ')
+
+const camelToKebab = _ => _.replace(/([A-Z])/g, $1 => "-" + $1.toLowerCase())
+
+export default createMapper({
+  breakpoints,
+  props: [
+    ...propsSupportingBreakpoints,
+    ...propsWithDuplicatedClassNames,
+    ...otherUtilityProps
+  ],
+  getter: ({ breakpoint, prop, value }) => {
+    if (breakpoint && !propsSupportingBreakpoints.includes(prop)) {
+      console.warn(new Error(`The prop "${prop}" does not support breakpoints, do not use the array notation.`))
+    }
+    if (value === false) {
+      return ''
+    }
+    const kebabProp = camelToKebab(prop)
+    if (propsWithDuplicatedClassNames.includes(prop) && value !== true) {
+      return kebabProp + ' ' + className({kebabProp, value})
+    }
+    return className({kebabProp, breakpoint, value})
+  }
+})

--- a/packages/system-classnames/test/bootstrap@4.2.test.js
+++ b/packages/system-classnames/test/bootstrap@4.2.test.js
@@ -1,0 +1,47 @@
+import test from 'ava'
+import React from 'react'
+import { create as render } from 'react-test-renderer'
+import bootstrap from '../src/bootstrap@4.2'
+
+const Box = props => <div {...bootstrap(props)} />
+
+test('basic use-case', t => {
+    const json = render(<Box m={[2, 3]} p={4} border/>).toJSON()
+    t.deepEqual(json.props, {className:'m-2 m-sm-3 p-4 border'})
+})
+
+test('warning for using array notation where it is not applicable', t => {
+    const warn = console.warn;
+    const warnings = []
+    console.warn = (warning) => warnings.push(warning)
+    const json = render(<Box bg={['primary', 'secondary']} />).toJSON()
+    t.deepEqual(json.props, {className: 'bg-primary bg-sm-secondary'})
+    t.is(warnings.length, 1)
+    t.deepEqual(warnings[0].message, 'The prop "bg" does not support breakpoints, do not use the array notation.')
+    console.warn = warn
+})
+
+test('false valued props', t => {
+    const json = render(<Box invisible={false} />).toJSON()
+    t.deepEqual(json.props, {className: ''})
+})
+
+test('implicit values', t => {
+    const json = render(<Box visible />).toJSON()
+    t.deepEqual(json.props, {className: 'visible'})
+})
+
+test('2 classes with the same prop name', t => {
+    const json = render(<Box border='primary' />).toJSON()
+    t.deepEqual(json.props, {className: 'border border-primary'})
+})
+
+test('prop with 2 values', t => {
+    const json = render(<Box d='flex' flex='row wrap' />).toJSON()
+    t.deepEqual(json.props, {className: 'd-flex flex-row flex-wrap'})
+})
+
+test('camel case to snake case', t => {
+    const json = render(<Box borderTop />).toJSON()
+    t.deepEqual(json.props, {className: 'border-top'})
+})


### PR DESCRIPTION
Great work on system-classnames! I use [bootstrap utils](https://getbootstrap.com/docs/4.2/utilities) quite often, and I figured it would be a good fit for system-classnames.