### PR TITLE
Add `themeGet` object literal syntax example

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ To learn more, see the [Getting Started](docs/getting-started.md) guide or read 
   - [Variants](docs/api.md#variants)
   - [Utilities](docs/api.md#utilities)
     - [themeGet](docs/api.md#themeget)
+    - [propTypes](docs/api.md#proptypes)
   - [Customize](docs/api.md#customize)
     - [style](docs/api.md#style)
     - [variant](docs/api.md#variant)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ To learn more, see the [Getting Started](docs/getting-started.md) guide or read 
   - [Misc](docs/api.md#misc)
   - [Variants](docs/api.md#variants)
   - [Utilities](docs/api.md#utilities)
-    - [get](docs/api.md#get)
+    - [themeGet](docs/api.md#themeget)
   - [Customize](docs/api.md#customize)
     - [style](docs/api.md#style)
     - [variant](docs/api.md#variant)

--- a/docs/api.md
+++ b/docs/api.md
@@ -430,7 +430,6 @@ import { themeGet } from 'styled-system'
 const Box = styled('div')(props => ({
   borderRadius: themeGet('radii.small', '4px')(props),
 }))
-`
 ```
 
 ### propTypes

--- a/docs/api.md
+++ b/docs/api.md
@@ -407,12 +407,29 @@ which can be helpful when unit testing styled-components.
 themeGet(objectPath, fallbackValue)(props)
 ```
 
+`themeGet` returns a function that accepts props as an argument
+(`themeGet(objectPath)(props)`), which when used in a tagged template
+literal should look like this:
+
 ```js
 import styled from 'styled-components'
 import { themeGet } from 'styled-system'
 
 const Box = styled.div`
   border-radius: ${themeGet('radii.small', '4px')};
+`
+```
+
+When used with object literal syntax, `themeGet` needs to be in a
+function call and have `props` passed to it:
+
+```js
+import styled from 'styled-components'
+import { themeGet } from 'styled-system'
+
+const Box = styled('div')(props => ({
+  borderRadius: themeGet('radii.small', '4px')(props),
+}))
 `
 ```
 


### PR DESCRIPTION
Also adjusts the link to `get` in the main README, and adds `propTypes` there.